### PR TITLE
[#18] Fix the `deploy` CLI to the deploy new parameters with tags.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fix the `deploy` CLI to the deploy new parameters with tags. [issue-18](https://github.com/lucasvieirasilva/aws-ssm-secrets-cli/issues/18)
+
 ## [1.0.1] - 2021-01-21
 
 ### Changed


### PR DESCRIPTION
#### Description

This PR fixes the `deploy` CLI to the deploy new parameters with tags.

**Issue**: #18