### PR TITLE
[#17] Fix the `deploy` CLI to the secrets without `--confirm` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix the `deploy` CLI to the deploy new parameters with tags. [issue-18](https://github.com/lucasvieirasilva/aws-ssm-secrets-cli/issues/18)
+- Fix the `deploy` CLI to the secrets without `--confirm` option. [issue-17](https://github.com/lucasvieirasilva/aws-ssm-secrets-cli/issues/17)
 
 ## [1.0.1] - 2021-01-21
 

--- a/aws_secrets/cli/deploy.py
+++ b/aws_secrets/cli/deploy.py
@@ -168,7 +168,7 @@ def deploy_secret(session, secret, global_tags, kms_arn, dry_run, confirm):
         print_secret_name(secret['name'])
         click.echo("--> New Secret")
 
-        if not dry_run and confirm and click.confirm("--> Would you to create this secret?"):
+        if not dry_run or (confirm and click.confirm("--> Would you to create this secret?")):
             create_secret(session, secret, kms_arn)
             return True
     else:


### PR DESCRIPTION
#### Description

This PR fixes the `deploy` CLI to the secrets without `--confirm` option.

**Issue**: #17