### PR TITLE
[#26] Add `!file` YAML resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Add `!file` YAML resolver. [issue-26](https://github.com/lucasvieirasilva/aws-ssm-secrets-cli/issues/26)
+
 ### Changed
 
 - Store the Ciphertext in a separate file. [issue-25](https://github.com/lucasvieirasilva/aws-ssm-secrets-cli/issues/25)

--- a/README.md
+++ b/README.md
@@ -289,6 +289,20 @@ aws-secrets deploy
 
 This CLI implements resolvers, which can be used to resolve the value of a command output or a CloudFormation output value.
 
+##### !file
+
+This resolver is designed to load a file content to the SSM Parameter or Secrets Manager Value.
+
+Example:
+
+```yaml
+...
+secrets:
+  - name: mysecret
+    value: !file myfile.txt
+...
+```
+
 ##### !cf_output
 
 This resolver can be used in `parameters[*].value`, `secrets[*].value` and `kms.arn` properties.

--- a/aws_secrets/__init__.py
+++ b/aws_secrets/__init__.py
@@ -3,12 +3,18 @@ import yaml
 from aws_secrets.representers.literal import Literal, literal_presenter
 from aws_secrets.tags.cmd import CmdTag
 from aws_secrets.tags.output_stack import OutputStackTag
+from aws_secrets.tags.file import FileTag
 
 yaml.SafeLoader.add_constructor('!cf_output', OutputStackTag.from_yaml)
 yaml.SafeDumper.add_multi_representer(
     OutputStackTag, OutputStackTag.to_yaml)
+
 yaml.SafeLoader.add_constructor('!cmd', CmdTag.from_yaml)
 yaml.SafeDumper.add_multi_representer(CmdTag, CmdTag.to_yaml)
+
+yaml.SafeLoader.add_constructor('!file', FileTag.from_yaml)
+yaml.SafeDumper.add_multi_representer(FileTag, FileTag.to_yaml)
+
 yaml.SafeDumper.add_representer(Literal, literal_presenter)
 
 __version__ = '1.2.0b1'

--- a/aws_secrets/cli/decrypt.py
+++ b/aws_secrets/cli/decrypt.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 import click
+from click.core import Context
 import yaml
 from aws_secrets.config.config_reader import ConfigReader
 from aws_secrets.helpers.catch_exceptions import catch_exceptions
@@ -12,8 +13,10 @@ from aws_secrets.miscellaneous import session
 @click.option('--output', type=click.Path())
 @click.option('--profile', help="AWS Profile", envvar='AWS_PROFILE')
 @click.option('--region', help="AWS Region", envvar='AWS_REGION')
+@click.pass_context
 @catch_exceptions
 def decrypt(
+    ctx: Context,
     env_file: str,
     output: Optional[str],
     profile: Optional[str],
@@ -23,11 +26,13 @@ def decrypt(
         Decrypt CLI Commmand `aws-secrets decrypt --help`
 
         Args:
+            ctx (`Context`): click context object
             env_file (`str`): configuration YAML file
             output (`str`, optional): output YAML file path
             profile (`str`, optional): AWS Profile
             region (`str`, optional): AWS Region
     """
+    ctx.obj['config_file'] = env_file
     session.aws_profile = profile
     session.aws_region = region
 

--- a/aws_secrets/cli/deploy.py
+++ b/aws_secrets/cli/deploy.py
@@ -5,6 +5,7 @@ import click
 from aws_secrets.config.config_reader import ConfigReader
 from aws_secrets.helpers.catch_exceptions import catch_exceptions
 from aws_secrets.miscellaneous import session
+from click.core import Context
 
 logger = logging.getLogger(__name__)
 
@@ -18,8 +19,10 @@ logger = logging.getLogger(__name__)
 @click.option('--only-parameters', help="Deploy only SSM Parameters", is_flag=True)
 @click.option('--profile', help="AWS Profile", envvar='AWS_PROFILE')
 @click.option('--region', help="AWS Region", envvar='AWS_REGION')
+@click.pass_context
 @catch_exceptions
 def deploy(
+    ctx: Context,
     env_file: str,
     filter_pattern: Optional[str],
     dry_run: bool,
@@ -33,6 +36,7 @@ def deploy(
         Deploy CLI Commmand `aws-secrets deploy --help`
 
         Args:
+            ctx (`Context`): click context object
             env_file (`str`): configuration YAML file
             filter_pattern (`str`, optional): resource filter pattern
             dry_run (`bool`): Dry run flag
@@ -42,6 +46,7 @@ def deploy(
             profile (`str`, optional): AWS Profile
             region (`str`, optional): AWS Region
     """
+    ctx.obj['config_file'] = env_file
     session.aws_profile = profile
     session.aws_region = region
 

--- a/aws_secrets/cli/encrypt.py
+++ b/aws_secrets/cli/encrypt.py
@@ -1,16 +1,20 @@
 from typing import Optional
+
 import click
 from aws_secrets.config.config_reader import ConfigReader
 from aws_secrets.helpers.catch_exceptions import catch_exceptions
 from aws_secrets.miscellaneous import session
+from click.core import Context
 
 
 @click.command(name='encrypt', help='Encrypt a configuration file')
 @click.option('-e', '--env-file', type=click.Path(), required=True)
 @click.option('--profile', help="AWS Profile", envvar='AWS_PROFILE')
 @click.option('--region', help="AWS Region", envvar='AWS_REGION')
+@click.pass_context
 @catch_exceptions
 def encrypt(
+    ctx: Context,
     env_file: str,
     profile: Optional[str],
     region: Optional[str]
@@ -19,10 +23,12 @@ def encrypt(
         Encrypt CLI Commmand `aws-secrets encrypt --help`
 
         Args:
+            ctx (`Context`): click context object
             env_file (`str`): configuration YAML file
             profile (`str`, optional): AWS Profile
             region (`str`, optional): AWS Region
     """
+    ctx.obj['config_file'] = env_file
     session.aws_profile = profile
     session.aws_region = region
 

--- a/aws_secrets/cli/set_parameter.py
+++ b/aws_secrets/cli/set_parameter.py
@@ -4,6 +4,7 @@ import click
 from aws_secrets.config.config_reader import ConfigReader
 from aws_secrets.helpers.catch_exceptions import catch_exceptions
 from aws_secrets.miscellaneous import session
+from click.core import Context
 
 
 @click.command(name='set-parameter', help='Add/Update SSM Parameters')
@@ -16,8 +17,10 @@ from aws_secrets.miscellaneous import session
 @click.option('-k', '--kms')
 @click.option('--profile', help="AWS Profile", envvar='AWS_PROFILE')
 @click.option('--region', help="AWS Region", envvar='AWS_REGION')
+@click.pass_context
 @catch_exceptions
 def set_parameter(
+    ctx: Context,
     env_file: str,
     name: str,
     description: Optional[str],
@@ -30,6 +33,7 @@ def set_parameter(
         Add/Update SSM Parameters CLI Commmand `aws-secrets set-parameter --help`
 
         Args:
+            ctx (`Context`): click context object
             env_file (`str`): configuration YAML file
             name (`str`): SSM parameter name
             description (`str`, optional): SSM parameter description
@@ -38,6 +42,7 @@ def set_parameter(
             profile (`str`, optional): AWS Profile
             region (`str`, optional): AWS Region
     """
+    ctx.obj['config_file'] = env_file
     session.aws_profile = profile
     session.aws_region = region
     config = ConfigReader(env_file)

--- a/aws_secrets/cli/set_secret.py
+++ b/aws_secrets/cli/set_secret.py
@@ -5,6 +5,7 @@ import click
 from aws_secrets.config.config_reader import ConfigReader
 from aws_secrets.helpers.catch_exceptions import catch_exceptions
 from aws_secrets.miscellaneous import session
+from click.core import Context
 
 logger = logging.getLogger(__name__)
 
@@ -16,8 +17,10 @@ logger = logging.getLogger(__name__)
 @click.option('-k', '--kms')
 @click.option('--profile', help="AWS Profile", envvar='AWS_PROFILE')
 @click.option('--region', help="AWS Region", envvar='AWS_REGION')
+@click.pass_context
 @catch_exceptions
 def set_secret(
+    ctx: Context,
     env_file: str,
     name: str,
     description: Optional[str],
@@ -29,6 +32,7 @@ def set_secret(
         Add/Update AWS Secrets Manager secrets CLI Commmand `aws-secrets set-secret --help`
 
         Args:
+            ctx (`Context`): click context object
             env_file (`str`): configuration YAML file
             name (`str`): SSM parameter name
             description (`str`, optional): SSM parameter description
@@ -36,6 +40,7 @@ def set_secret(
             profile (`str`, optional): AWS Profile
             region (`str`, optional): AWS Region
     """
+    ctx.obj['config_file'] = env_file
     session.aws_profile = profile
     session.aws_region = region
 

--- a/aws_secrets/cli/view_parameter.py
+++ b/aws_secrets/cli/view_parameter.py
@@ -1,8 +1,10 @@
 from typing import Optional
+
 import click
 from aws_secrets.config.config_reader import ConfigReader
 from aws_secrets.helpers.catch_exceptions import CLIError, catch_exceptions
 from aws_secrets.miscellaneous import session
+from click.core import Context
 
 
 @click.command(name='view-parameter', help='View decrypted SSM parameter value')
@@ -10,8 +12,10 @@ from aws_secrets.miscellaneous import session
 @click.option('-n', '--name', required=True)
 @click.option('--profile', help="AWS Profile", envvar='AWS_PROFILE')
 @click.option('--region', help="AWS Region", envvar='AWS_REGION')
+@click.pass_context
 @catch_exceptions
 def view_parameter(
+    ctx: Context,
     env_file: str,
     name: str,
     profile: Optional[str],
@@ -21,11 +25,13 @@ def view_parameter(
         View SSM Parameter value CLI Commmand `aws-secrets view-parameter --help`
 
         Args:
+            ctx (`Context`): click context object
             env_file (`str`): configuration YAML file
             name (`str`): SSM parameter name
             profile (`str`, optional): AWS Profile
             region (`str`, optional): AWS Region
     """
+    ctx.obj['config_file'] = env_file
     session.aws_profile = profile
     session.aws_region = region
 

--- a/aws_secrets/cli/view_secret.py
+++ b/aws_secrets/cli/view_secret.py
@@ -1,8 +1,10 @@
 from typing import Optional
+
 import click
 from aws_secrets.config.config_reader import ConfigReader
 from aws_secrets.helpers.catch_exceptions import CLIError, catch_exceptions
 from aws_secrets.miscellaneous import session
+from click.core import Context
 
 
 @click.command(name='view-secret', help='View decrypted AWS Secrets Manager secret value')
@@ -10,8 +12,10 @@ from aws_secrets.miscellaneous import session
 @click.option('-n', '--name', required=True)
 @click.option('--profile', help="AWS Profile", envvar='AWS_PROFILE')
 @click.option('--region', help="AWS Region", envvar='AWS_REGION')
+@click.pass_context
 @catch_exceptions
 def view_secret(
+    ctx: Context,
     env_file: str,
     name: str,
     profile: Optional[str],
@@ -21,11 +25,13 @@ def view_secret(
         View AWS Secrets Manager secret value CLI Commmand `aws-secrets view-parameter --help`
 
         Args:
+            ctx (`Context`): click context object
             env_file (`str`): configuration YAML file
             name (`str`): SSM parameter name
             profile (`str`, optional): AWS Profile
             region (`str`, optional): AWS Region
     """
+    ctx.obj['config_file'] = env_file
     session.aws_profile = profile
     session.aws_region = region
 

--- a/aws_secrets/tags/file.py
+++ b/aws_secrets/tags/file.py
@@ -1,0 +1,63 @@
+import logging
+import os
+from pathlib import Path
+
+import click
+import yaml
+from aws_secrets.helpers.catch_exceptions import CLIError
+from yaml.dumper import SafeDumper
+from yaml.nodes import ScalarNode
+
+
+class FileTag(yaml.YAMLObject):
+    """
+        Custom YAML tag class
+        !file tag read the content from a file
+
+        Examples:
+            >>> !file /path/file.txt
+            value: `'hello'`
+
+        Args:
+            value (`str`): file path
+
+        Attributes:
+            value (`str`): file path
+            logger (`Logger`): logger instance
+    """
+
+    yaml_tag = u'!file'
+
+    def __init__(self, value: str):
+        self.value = value
+        self.logger = logging.getLogger(__name__)
+
+    def __repr__(self) -> str:
+        """
+            Resolve the file path and read the content
+
+            Returns:
+                `str` file content
+        """
+        click_ctx = click.get_current_context(silent=True)
+        working_dir = os.getcwd()
+
+        if click_ctx:
+            config_file = click.get_current_context(silent=True).obj.get('config_file', None)
+            if config_file is not None:
+                working_dir = os.path.basename(config_file)
+
+        source_file_path = Path(os.path.relpath(self.value, working_dir)).resolve()
+
+        if source_file_path.exists():
+            return source_file_path.read_text()
+        else:
+            raise CLIError(f"File '{source_file_path}' not found")
+
+    @classmethod
+    def from_yaml(cls, _, node):
+        return FileTag(node.value)
+
+    @classmethod
+    def to_yaml(cls, dumper: SafeDumper, data) -> ScalarNode:
+        return dumper.represent_scalar(cls.yaml_tag, data.value)

--- a/aws_secrets/tags/file.py
+++ b/aws_secrets/tags/file.py
@@ -43,9 +43,8 @@ class FileTag(yaml.YAMLObject):
         working_dir = os.getcwd()
 
         if click_ctx:
-            config_file = click.get_current_context(silent=True).obj.get('config_file', None)
-            if config_file is not None:
-                working_dir = os.path.basename(config_file)
+            config_file = click_ctx.obj.get('config_file', '')
+            working_dir = os.path.dirname(config_file)
 
         source_file_path = Path(os.path.relpath(self.value, working_dir)).resolve()
 

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -152,6 +152,9 @@ def test_deploy_secrets(
             _secrets_stubs(stubber)
 
             with mock_cli_runner.isolated_filesystem():
+                with open('hello.txt', 'w') as f:
+                    f.write("Hello")
+
                 with open(config_file, 'w') as config:
                     with open(config_file, 'w') as config:
                         config.write(f"""kms:
@@ -160,6 +163,8 @@ secrets:
 - name: secret1
 - name: secret2
   value: !cmd 'value'
+- name: secret3
+  value: !file 'hello.txt'
 secrets_file: ./config.secrets.yaml
 """)
                 with open(secrets_file, 'w') as secrets:
@@ -201,6 +206,9 @@ def test_deploy_secrets_only_secrets_flag(
             _secrets_stubs(stubber)
 
             with mock_cli_runner.isolated_filesystem():
+                with open('hello.txt', 'w') as f:
+                    f.write("Hello")
+
                 with open(config_file, 'w') as config:
                     with open(config_file, 'w') as config:
                         config.write(f"""kms:
@@ -212,6 +220,8 @@ secrets:
 - name: secret1
 - name: secret2
   value: !cmd 'value'
+- name: secret3
+  value: !file 'hello.txt'
 secrets_file: ./config.secrets.yaml
 """)
                 with open(secrets_file, 'w') as secrets:
@@ -278,6 +288,22 @@ def _secrets_stubs(stubber):
     stubber.add_response('untag_resource', {}, {
         'SecretId': 'secret2',
         'TagKeys': []
+    })
+    stubber.add_response('list_secrets', {
+        'SecretList': []
+    }, {
+        'Filters': [
+            {
+                'Key': 'name',
+                'Values': ['secret3']
+            }
+        ]
+    })
+    stubber.add_response('create_secret', {}, {
+        'Name': 'secret3',
+        'Description': '',
+        'SecretString': 'Hello',
+        'Tags': []
     })
 
 

--- a/tests/tags/test_file.py
+++ b/tests/tags/test_file.py
@@ -1,0 +1,24 @@
+import pytest
+import yaml
+from aws_secrets.tags.file import FileTag
+
+
+@pytest.mark.parametrize("file_path,content", [
+    ('file.txt', "hello world"),
+    ('subdir/file.txt', "hello world2"),
+    ('../file.txt', "hello world3"),
+])
+def test_file_tag(fs, file_path, content):
+    """
+        Should resolve the file in the same folder
+    """
+    fs.create_file(file_path, contents=content)
+
+    yaml.SafeLoader.add_constructor('!file', FileTag.from_yaml)
+    yaml.SafeDumper.add_multi_representer(FileTag, FileTag.to_yaml)
+
+    data = yaml.safe_load(f"""
+key: !file {file_path}
+""")
+
+    assert str(data['key']) == content

--- a/tests/tags/test_file.py
+++ b/tests/tags/test_file.py
@@ -1,6 +1,7 @@
 import pytest
 import yaml
 from aws_secrets.tags.file import FileTag
+from aws_secrets.helpers.catch_exceptions import CLIError
 
 
 @pytest.mark.parametrize("file_path,content", [
@@ -22,3 +23,34 @@ key: !file {file_path}
 """)
 
     assert str(data['key']) == content
+
+
+def test_file_tag_not_found(fs):
+    """
+        Should resolve the file in the same folder
+    """
+    yaml.SafeLoader.add_constructor('!file', FileTag.from_yaml)
+    yaml.SafeDumper.add_multi_representer(FileTag, FileTag.to_yaml)
+
+    data = yaml.safe_load("""
+key: !file not_found.txt
+""")
+
+    with pytest.raises(CLIError) as error:
+        print(str(data['key']))
+
+    assert str(error.value) == "File '/not_found.txt' not found"
+
+
+def test_cmd_yaml_tag_dump():
+    """
+        Should generate the YAML correctly
+    """
+    yaml.SafeLoader.add_constructor('!file', FileTag.from_yaml)
+    yaml.SafeDumper.add_multi_representer(FileTag, FileTag.to_yaml)
+
+    data = yaml.safe_load("""
+key: !file hello.txt
+""")
+
+    assert yaml.safe_dump(data) == "key: !file 'hello.txt'\n"


### PR DESCRIPTION
#### Description

This PR adds the `!file` YAML resolver.

The resolver is designed to load a file content to the SSM Parameter or Secrets Manager Value.

Example:

```yaml
...
secrets:
  - name: mysecret
    value: !file myfile.txt
...
```

#### Resolved Issues

- #26

#### Checklist

- [x] Update Documentation
- [x] Update CHANGELOG
- [x] Update Functions/Classes Docstrings
- [x] Update unit tests
