### PR TITLE
Add `tier` property in the SSM parameter section #27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Add `Tier` property in the SSM parameter section. [issue-27](https://github.com/lucasvieirasilva/aws-ssm-secrets-cli/issues/27)
+
 ### Changed
 
 - Add Schema Validation for the SSM Parameters and Secrets Manager. [issue-42](https://github.com/lucasvieirasilva/aws-ssm-secrets-cli/issues/42)

--- a/README.md
+++ b/README.md
@@ -136,6 +136,30 @@ aws-secrets deploy -e dev.yaml --profile myaws-profile --region eu-west-1
 
 Now your parameters have been created in AWS Account.
 
+## Configuration Schema
+
+```yaml
+tags: # Global tags, applied to all the resources
+  key: 'string' # key/value pair
+kms:
+  arn: 'string' # Required, KMS ARN
+parameters: # AWS SSM Parameter Section
+  - name: 'string' # Required, Parameter Name
+    description: 'string' # Optional, Parameter Description
+    type: 'String|SecureString' # Required, Parameter Type
+    value: 'string' # Required only for Type 'String' or if it is some YAML tag (e.g. !file or !cmd)
+    tier: 'Standard|Advanced|Intelligent-Tiering' # Optional, Parameter Tier, default 'Standard'
+    tags: # Optional, Parameter Tags, it is extended with the global tags
+      key: 'string'
+secrets: # AWS Secrets Manager secrets Section
+  - name: 'string' # Required, Secret Name
+    description: 'string' # Optional, Secret Description
+    value: 'string' # Required only if it is some YAML tag (e.g. !file or !cmd)
+    tags: # Optional, Secret Tags, it is extended with the global tags
+      key: 'string'
+secrets_file: 'Path' # Optional, Secrets file path, default '<config-filename>.secrets.yaml'
+```
+
 ## Command Line Interface
 
 Command options differ depending on the command, and can be found by running:

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -324,13 +324,15 @@ def _ssm_parameters_stubs(stubber):
         'Description': '',
         'Type': 'SecureString',
         'Value': 'PlainTextData',
+        'Tier': 'Standard',
         'Tags': []
     })
     stubber.add_response('describe_parameters', {
         'Parameters': [{
             'Name': 'ssm2',
             'Description': '',
-            'Type': 'String'
+            'Type': 'String',
+            'Tier': 'Standard'
         }]
     }, {
         'ParameterFilters': [
@@ -360,6 +362,7 @@ def _ssm_parameters_stubs(stubber):
         'Description': '',
         'Type': 'String',
         'Value': 'PlainText2',
+        'Tier': 'Standard',
         'Overwrite': True,
     })
     stubber.add_response('remove_tags_from_resource', {}, {
@@ -383,13 +386,15 @@ def _ssm_parameters_stubs(stubber):
         'Description': '',
         'Type': 'String',
         'Value': 'myvalue',
+        'Tier': 'Standard',
         'Tags': []
     })
     stubber.add_response('describe_parameters', {
         'Parameters': [{
             'Name': 'ssm4',
             'Description': '',
-            'Type': 'SecureString'
+            'Type': 'SecureString',
+            'Tier': 'Standard'
         }]
     }, {
         'ParameterFilters': [
@@ -419,6 +424,7 @@ def _ssm_parameters_stubs(stubber):
         'Description': '',
         'Type': 'SecureString',
         'Value': 'myvalue',
+        'Tier': 'Standard',
         'Overwrite': True
     })
     stubber.add_response('remove_tags_from_resource', {}, {

--- a/tests/config/providers/ssm/test_provider.py
+++ b/tests/config/providers/ssm/test_provider.py
@@ -394,7 +394,8 @@ def test_ssm_provider_deploy_dry_run(
                 'Parameters': [{
                     'Name': 'ssm-param1',
                     'Description': '',
-                    'Type': 'String'
+                    'Type': 'String',
+                    'Tier': 'Standard'
                 }]
             }, {
                 'ParameterFilters': [
@@ -423,7 +424,8 @@ def test_ssm_provider_deploy_dry_run(
                 'Parameters': [{
                     'Name': 'ssm-param2',
                     'Description': '',
-                    'Type': 'SecureString'
+                    'Type': 'SecureString',
+                    'Tier': 'Standard'
                 }]
             }, {
                 'ParameterFilters': [
@@ -520,7 +522,8 @@ def test_ssm_provider_deploy_confirm_no(
                 'Parameters': [{
                     'Name': 'ssm-param1',
                     'Description': '',
-                    'Type': 'String'
+                    'Type': 'String',
+                    'Tier': 'Standard'
                 }]
             }, {
                 'ParameterFilters': [
@@ -549,7 +552,8 @@ def test_ssm_provider_deploy_confirm_no(
                 'Parameters': [{
                     'Name': 'ssm-param2',
                     'Description': '',
-                    'Type': 'SecureString'
+                    'Type': 'SecureString',
+                    'Tier': 'Standard'
                 }]
             }, {
                 'ParameterFilters': [
@@ -644,13 +648,15 @@ def test_ssm_provider_deploy(
                 'Description': '',
                 'Type': 'String',
                 'Value': 'PlainTextData',
+                'Tier': 'Standard',
                 'Tags': []
             })
             stubber.add_response('describe_parameters', {
                 'Parameters': [{
                     'Name': 'ssm-param1',
                     'Description': '',
-                    'Type': 'String'
+                    'Type': 'String',
+                    'Tier': 'Standard'
                 }]
             }, {
                 'ParameterFilters': [
@@ -679,7 +685,8 @@ def test_ssm_provider_deploy(
                 'Parameters': [{
                     'Name': 'ssm-param2',
                     'Description': '',
-                    'Type': 'SecureString'
+                    'Type': 'SecureString',
+                    'Tier': 'Standard'
                 }]
             }, {
                 'ParameterFilters': [
@@ -709,6 +716,7 @@ def test_ssm_provider_deploy(
                 'Description': '',
                 'Type': 'SecureString',
                 'Value': 'PlainTextData',
+                'Tier': 'Standard',
                 'Overwrite': True
             })
             stubber.add_response('remove_tags_from_resource', {}, {
@@ -774,7 +782,8 @@ def test_ssm_provider_deploy_no_changes(
                 'Parameters': [{
                     'Name': 'ssm-param1',
                     'Description': '',
-                    'Type': 'String'
+                    'Type': 'String',
+                    'Tier': 'Standard'
                 }]
             }, {
                 'ParameterFilters': [
@@ -845,7 +854,8 @@ def test_ssm_provider_deploy_non_replaceable_attrs(
                 'Parameters': [{
                     'Name': 'ssm-param1',
                     'Description': '',
-                    'Type': 'String'
+                    'Type': 'String',
+                    'Tier': 'Standard'
                 }]
             }, {
                 'ParameterFilters': [
@@ -878,6 +888,7 @@ def test_ssm_provider_deploy_non_replaceable_attrs(
                 'Description': '',
                 'Type': 'SecureString',
                 'Value': 'PlainTextData',
+                'Tier': 'Standard',
                 'Tags': []
             })
 
@@ -928,7 +939,8 @@ def test_ssm_provider_deploy_non_replaceable_attrs_confirm_no(
                 'Parameters': [{
                     'Name': 'ssm-param1',
                     'Description': '',
-                    'Type': 'String'
+                    'Type': 'String',
+                    'Tier': 'Standard'
                 }]
             }, {
                 'ParameterFilters': [


### PR DESCRIPTION
#### Description

This PR adds the `tier` property in the SSM parameter section #27

#### Resolved Issues

- #27

#### Checklist

- [x] Update Documentation
- [x] Update CHANGELOG
- [x] Update Functions/Classes Docstrings
- [x] Update unit tests
