### PR TITLE
fix: Correct session import on output_stack.py

### DIFF
--- a/aws_secrets/tags/output_stack.py
+++ b/aws_secrets/tags/output_stack.py
@@ -3,8 +3,7 @@ from yaml.dumper import SafeDumper
 from yaml.nodes import ScalarNode
 
 from aws_secrets.helpers.catch_exceptions import CLIError
-from aws_secrets.miscellaneous import cloudformation
-from aws_secrets.miscellaneous.session import session
+from aws_secrets.miscellaneous import cloudformation, session
 
 
 class OutputStackTag(yaml.YAMLObject):
@@ -53,7 +52,7 @@ class OutputStackTag(yaml.YAMLObject):
         except IndexError:
             pass
 
-        return cloudformation.get_output_value(session(), stack_name, output_name)
+        return cloudformation.get_output_value(session.session(), stack_name, output_name)
 
     @classmethod
     def from_yaml(cls, _, node):


### PR DESCRIPTION
#### Description

This fix an import issue with the PR that tried to solve issue 54

#### Resolved Issues

https://github.com/lucasvieirasilva/aws-ssm-secrets-cli/issues/54

#### Checklist

- [x] Update Documentation
- [x] Update CHANGELOG
- [x] Update Functions/Classes Docstrings
- [x] Update unit tests
