### PR TITLE
feat: improve set-parameter and set-secret commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage/
 .coverage
 venv
 .venv
+.DS_Store

--- a/aws_secrets/cli/cli.py
+++ b/aws_secrets/cli/cli.py
@@ -1,5 +1,5 @@
 import click
-import yaml
+
 from aws_secrets import __name__ as module_name
 from aws_secrets.cli.decrypt import decrypt
 from aws_secrets.cli.deploy import deploy
@@ -11,46 +11,32 @@ from aws_secrets.cli.view_parameter import view_parameter
 from aws_secrets.cli.view_secret import view_secret
 from aws_secrets.helpers.catch_exceptions import catch_exceptions
 from aws_secrets.helpers.logging import setup_logging
-from aws_secrets.representers.literal import Literal, literal_presenter
-from aws_secrets.tags.cmd import CmdTag
-from aws_secrets.tags.file import FileTag
-from aws_secrets.tags.output_stack import OutputStackTag
-
-yaml.SafeLoader.add_constructor('!cf_output', OutputStackTag.from_yaml)
-yaml.SafeDumper.add_multi_representer(
-    OutputStackTag, OutputStackTag.to_yaml)
-
-yaml.SafeLoader.add_constructor('!cmd', CmdTag.from_yaml)
-yaml.SafeDumper.add_multi_representer(CmdTag, CmdTag.to_yaml)
-
-yaml.SafeLoader.add_constructor('!file', FileTag.from_yaml)
-yaml.SafeDumper.add_multi_representer(FileTag, FileTag.to_yaml)
-
-yaml.SafeDumper.add_representer(Literal, literal_presenter)
 
 
-@click.group(help='AWS Secrets CLI')
+@click.group(help="AWS Secrets CLI")
 @click.option(
-    '--loglevel',
-    help='Log level.',
+    "--loglevel",
+    help="Log level.",
     required=False,
-    default='WARNING',
+    default="WARNING",
     show_default=True,
-    type=click.Choice(['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'], case_sensitive=False)
+    type=click.Choice(
+        ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"], case_sensitive=False
+    ),
 )
 @click.pass_context
 @catch_exceptions
 def cli(ctx, loglevel: str):
     """
-        Root CLI Group `aws-secrets --help`
+    Root CLI Group `aws-secrets --help`
 
-        Args:
-            ctx (`click.Context`): click context object
-            loglevel (`str`): log level
+    Args:
+        ctx (`click.Context`): click context object
+        loglevel (`str`): log level
     """
 
     ctx.ensure_object(dict)
-    ctx.obj['loglevel'] = loglevel
+    ctx.obj["loglevel"] = loglevel
 
     setup_logging(module_name, loglevel)
 

--- a/aws_secrets/cli/decrypt.py
+++ b/aws_secrets/cli/decrypt.py
@@ -2,10 +2,11 @@ from typing import Optional
 
 import click
 from click.core import Context
-import yaml
+
 from aws_secrets.config.config_reader import ConfigReader
 from aws_secrets.helpers.catch_exceptions import catch_exceptions
 from aws_secrets.miscellaneous import session
+from aws_secrets.yaml import yaml
 
 
 @click.command(name='decrypt', help='Decrypt a configuration file')
@@ -41,4 +42,4 @@ def decrypt(
 
     output_file = output if output else f"{env_file}.dec"
     with open(output_file, 'w') as outfile:
-        yaml.safe_dump(config.data, outfile)
+        yaml.dump(config.data, outfile)

--- a/aws_secrets/cli/set_parameter.py
+++ b/aws_secrets/cli/set_parameter.py
@@ -1,76 +1,117 @@
 from typing import Optional
 
 import click
+from click.core import Context
+from prompt_toolkit import HTML, prompt
+
 from aws_secrets.config.config_reader import ConfigReader
 from aws_secrets.helpers.catch_exceptions import catch_exceptions
 from aws_secrets.miscellaneous import session
-from click.core import Context
+from aws_secrets.miscellaneous.prompt import (
+    DEFAULT_PROMPT_SYLE, get_multiline_input_save_keyboard, radiolist_prompt)
 
 
-@click.command(name='set-parameter', help='Add/Update SSM Parameters')
-@click.option('-e', '--env-file', type=click.Path(), required=True)
-@click.option('-n', '--name', prompt=True, required=True)
-@click.option('-d', '--description', help='SSM Parameter Description', required=False)
-@click.option('-t', '--type',
-              required=True, type=click.Choice(['String', 'SecureString'], case_sensitive=True),
-              default='SecureString')
-@click.option('-k', '--kms')
-@click.option('--profile', help="AWS Profile", envvar='AWS_PROFILE')
-@click.option('--region', help="AWS Region", envvar='AWS_REGION')
+@click.command(name="set-parameter", help="Add/Update SSM Parameters")
+@click.option("-e", "--env-file", type=click.Path(), required=True)
+@click.option("-n", "--name", required=False)
+@click.option("-d", "--description", help="SSM Parameter Description", required=False)
+@click.option("-v", "--value", help="SSM Parameter Value", required=False)
+@click.option(
+    "-t",
+    "--type",
+    required=False,
+    type=click.Choice(["String", "SecureString"], case_sensitive=True),
+)
+@click.option("-k", "--kms")
+@click.option("--profile", help="AWS Profile", envvar="AWS_PROFILE")
+@click.option("--region", help="AWS Region", envvar="AWS_REGION")
 @click.pass_context
 @catch_exceptions
 def set_parameter(
     ctx: Context,
     env_file: str,
-    name: str,
+    name: Optional[str],
     description: Optional[str],
-    type: str,
+    value: Optional[str],
+    type: Optional[str],
     kms: Optional[str],
     profile: Optional[str],
-    region: Optional[str]
+    region: Optional[str],
 ):
     """
-        Add/Update SSM Parameters CLI Commmand `aws-secrets set-parameter --help`
+    Add/Update SSM Parameters CLI Commmand `aws-secrets set-parameter --help`
 
-        Args:
-            ctx (`Context`): click context object
-            env_file (`str`): configuration YAML file
-            name (`str`): SSM parameter name
-            description (`str`, optional): SSM parameter description
-            type (`str`): SSM parameter type
-            kms (`str`, optional): SSM parameter KMS Arn or Id
-            profile (`str`, optional): AWS Profile
-            region (`str`, optional): AWS Region
+    Args:
+        ctx (`Context`): click context object
+        env_file (`str`): configuration YAML file
+        name (`str`, optional): SSM parameter name
+        description (`str`, optional): SSM parameter description
+        type (`str`, optional): SSM parameter type
+        kms (`str`, optional): SSM parameter KMS Arn or Id
+        profile (`str`, optional): AWS Profile
+        region (`str`, optional): AWS Region
     """
-    ctx.obj['config_file'] = env_file
+    ctx.obj["config_file"] = env_file
     session.aws_profile = profile
     session.aws_region = region
     config = ConfigReader(env_file)
-    provider = config.get_provider('parameters')
+    provider = config.get_provider("parameters")
 
-    context_data = {
-        'name': name,
-        'type': type,
-    }
+    context_data = {"name": name}
+    if not name:
+        context_data["name"] = prompt(
+            HTML(
+                "<question><question_mark>?</question_mark> What is the name of the SSM parameter? </question>"
+            ),
+            style=DEFAULT_PROMPT_SYLE,
+        )
+
+    parameter = provider.find(context_data["name"])
 
     if description:
-        context_data['description'] = description
+        context_data["description"] = description
+    else:
+        context_data["description"] = prompt(
+            HTML(
+                "<question><question_mark>?</question_mark> What is the description of the parameter? </question>"
+            ),
+            default=parameter.description if parameter else "",
+            style=DEFAULT_PROMPT_SYLE,
+        )
+
+    if type:
+        context_data["type"] = type
+    else:
+        context_data["type"] = radiolist_prompt(
+            title=HTML(
+                "<question><question_mark>?</question_mark> What is the type of the parameter? </question>"
+            ),
+            values=[
+                ("String", "String"),
+                ("SecureString", "SecureString"),
+            ],
+            default=parameter.type if parameter else "SecureString",
+        )
 
     if kms:
-        context_data['kms'] = kms
+        context_data["kms"] = kms
 
-    click.echo("Enter/Paste your secret. Ctrl-D or Ctrl-Z ( windows ) to save it.")
-    contents = []
-    while True:
-        try:
-            line = input()
-        except EOFError:
-            break
-        contents.append(line)
+    if not value:
+        initial_value = ""
+        if parameter is not None:
+            initial_value = parameter.decrypt(format=True)
 
-    context_data['value'] = '\n'.join(contents)
+        click.echo(
+            f"Press {get_multiline_input_save_keyboard()} or [Esc] followed by [Enter] to accept input."
+        )
+        input_value = prompt("", multiline=True, default=initial_value)
+        if input_value.strip() == "":
+            return
 
-    parameter = provider.find(name)
+        context_data["value"] = input_value
+    else:
+        context_data["value"] = value
+
     if parameter is None:
         parameter = provider.add(context_data)
     else:

--- a/aws_secrets/cli/set_secret.py
+++ b/aws_secrets/cli/set_secret.py
@@ -1,74 +1,108 @@
 import logging
+import textwrap
 from typing import Optional
 
 import click
+from click.core import Context
+from prompt_toolkit import HTML, prompt
+
 from aws_secrets.config.config_reader import ConfigReader
 from aws_secrets.helpers.catch_exceptions import catch_exceptions
 from aws_secrets.miscellaneous import session
-from click.core import Context
+from aws_secrets.miscellaneous.prompt import (
+    DEFAULT_PROMPT_SYLE, get_multiline_input_save_keyboard)
 
 logger = logging.getLogger(__name__)
 
 
-@click.command(name='set-secret', help='Add/Update AWS Secrets Manager secrets')
-@click.option('-e', '--env-file', type=click.Path(), required=True)
-@click.option('-n', '--name', required=True)
-@click.option('-d', '--description', help='Secret Description', required=False)
-@click.option('-k', '--kms')
-@click.option('--profile', help="AWS Profile", envvar='AWS_PROFILE')
-@click.option('--region', help="AWS Region", envvar='AWS_REGION')
+@click.command(name="set-secret", help="Add/Update AWS Secrets Manager secrets")
+@click.option("-e", "--env-file", type=click.Path(), required=True)
+@click.option("-n", "--name", required=False)
+@click.option("-d", "--description", help="Secret Description", required=False)
+@click.option("-v", "--value", help="Secret Value", required=False)
+@click.option("-k", "--kms")
+@click.option("--profile", help="AWS Profile", envvar="AWS_PROFILE")
+@click.option("--region", help="AWS Region", envvar="AWS_REGION")
 @click.pass_context
 @catch_exceptions
 def set_secret(
     ctx: Context,
     env_file: str,
-    name: str,
+    name: Optional[str],
     description: Optional[str],
+    value: Optional[str],
     kms: Optional[str],
     profile: Optional[str],
-    region: Optional[str]
+    region: Optional[str],
 ):
     """
-        Add/Update AWS Secrets Manager secrets CLI Commmand `aws-secrets set-secret --help`
+    Add/Update AWS Secrets Manager secrets CLI Commmand `aws-secrets set-secret --help`
 
-        Args:
-            ctx (`Context`): click context object
-            env_file (`str`): configuration YAML file
-            name (`str`): SSM parameter name
-            description (`str`, optional): SSM parameter description
-            kms (`str`, optional): SSM parameter KMS Arn or Id
-            profile (`str`, optional): AWS Profile
-            region (`str`, optional): AWS Region
+    Args:
+        ctx (`Context`): click context object
+        env_file (`str`): configuration YAML file
+        name (`str`, optional): SSM parameter name
+        description (`str`, optional): SSM parameter description
+        kms (`str`, optional): SSM parameter KMS Arn or Id
+        profile (`str`, optional): AWS Profile
+        region (`str`, optional): AWS Region
     """
-    ctx.obj['config_file'] = env_file
+    ctx.obj["config_file"] = env_file
     session.aws_profile = profile
     session.aws_region = region
 
     config = ConfigReader(env_file)
-    provider = config.get_provider('secrets')
+    provider = config.get_provider("secrets")
 
-    context_data = {
-        'name': name
-    }
+    context_data = {"name": name}
+    if not name:
+        context_data["name"] = prompt(
+            HTML(
+                "<question><question_mark>?</question_mark> What is the name of the secret? </question>"
+            ),
+            style=DEFAULT_PROMPT_SYLE,
+        )
+
+    secret = provider.find(context_data["name"])
 
     if description:
-        context_data['description'] = description
+        context_data["description"] = description
+    else:
+        context_data["description"] = prompt(
+            HTML(
+                "<question><question_mark>?</question_mark> What is the description of the secret? </question>"
+            ),
+            default=secret.description if secret else "",
+            style=DEFAULT_PROMPT_SYLE,
+        )
 
     if kms:
-        context_data['kms'] = kms
+        context_data["kms"] = kms
 
-    click.echo("Enter/Paste your secret. Ctrl-D or Ctrl-Z ( windows ) to save it.")
-    contents = []
-    while True:
-        try:
-            line = input()
-        except EOFError:
-            break
-        contents.append(line)
+    if not value:
+        initial_value = ""
+        if secret is not None:
+            initial_value = secret.decrypt(format=True)
 
-    context_data['value'] = '\n'.join(contents)
+        input_value = prompt(
+            HTML(
+                textwrap.dedent(f"""\
+                    <question><question_mark>?</question_mark> What is the value of the secret?
+                    Press {get_multiline_input_save_keyboard()} or [Esc] followed by [Enter] to accept input.
+                    </question>
+                    """)
+            ),
+            multiline=True,
+            default=initial_value,
+            style=DEFAULT_PROMPT_SYLE,
+        )
+        if input_value.strip() == "":
+            return
 
-    secret = provider.find(name)
+        context_data["value"] = input_value
+    else:
+        context_data["value"] = value
+
     if secret is None:
         secret = provider.add(context_data)
     else:

--- a/aws_secrets/cli/view_parameter.py
+++ b/aws_secrets/cli/view_parameter.py
@@ -1,17 +1,18 @@
 from typing import Optional
 
 import click
+from click.core import Context
+
 from aws_secrets.config.config_reader import ConfigReader
 from aws_secrets.helpers.catch_exceptions import CLIError, catch_exceptions
 from aws_secrets.miscellaneous import session
-from click.core import Context
 
 
-@click.command(name='view-parameter', help='View decrypted SSM parameter value')
-@click.option('-e', '--env-file', type=click.Path(), required=True)
-@click.option('-n', '--name', required=True)
-@click.option('--profile', help="AWS Profile", envvar='AWS_PROFILE')
-@click.option('--region', help="AWS Region", envvar='AWS_REGION')
+@click.command(name="view-parameter", help="View decrypted SSM parameter value")
+@click.option("-e", "--env-file", type=click.Path(), required=True)
+@click.option("-n", "--name", required=True)
+@click.option("--profile", help="AWS Profile", envvar="AWS_PROFILE")
+@click.option("--region", help="AWS Region", envvar="AWS_REGION")
 @click.pass_context
 @catch_exceptions
 def view_parameter(
@@ -19,27 +20,27 @@ def view_parameter(
     env_file: str,
     name: str,
     profile: Optional[str],
-    region: Optional[str]
+    region: Optional[str],
 ):
     """
-        View SSM Parameter value CLI Commmand `aws-secrets view-parameter --help`
+    View SSM Parameter value CLI Commmand `aws-secrets view-parameter --help`
 
-        Args:
-            ctx (`Context`): click context object
-            env_file (`str`): configuration YAML file
-            name (`str`): SSM parameter name
-            profile (`str`, optional): AWS Profile
-            region (`str`, optional): AWS Region
+    Args:
+        ctx (`Context`): click context object
+        env_file (`str`): configuration YAML file
+        name (`str`): SSM parameter name
+        profile (`str`, optional): AWS Profile
+        region (`str`, optional): AWS Region
     """
-    ctx.obj['config_file'] = env_file
+    ctx.obj["config_file"] = env_file
     session.aws_profile = profile
     session.aws_region = region
 
     config = ConfigReader(env_file)
-    provider = config.get_provider('parameters')
+    provider = config.get_provider("parameters")
     parameter = provider.find(name)
 
     if parameter is None:
-        raise CLIError(f'parameter {name} not found')
+        raise CLIError(f"parameter {name} not found")
 
-    click.echo(parameter.decrypt())
+    click.echo(parameter.decrypt(format=True))

--- a/aws_secrets/cli/view_secret.py
+++ b/aws_secrets/cli/view_secret.py
@@ -1,17 +1,20 @@
 from typing import Optional
 
 import click
+from click.core import Context
+
 from aws_secrets.config.config_reader import ConfigReader
 from aws_secrets.helpers.catch_exceptions import CLIError, catch_exceptions
 from aws_secrets.miscellaneous import session
-from click.core import Context
 
 
-@click.command(name='view-secret', help='View decrypted AWS Secrets Manager secret value')
-@click.option('-e', '--env-file', type=click.Path(), required=True)
-@click.option('-n', '--name', required=True)
-@click.option('--profile', help="AWS Profile", envvar='AWS_PROFILE')
-@click.option('--region', help="AWS Region", envvar='AWS_REGION')
+@click.command(
+    name="view-secret", help="View decrypted AWS Secrets Manager secret value"
+)
+@click.option("-e", "--env-file", type=click.Path(), required=True)
+@click.option("-n", "--name", required=True)
+@click.option("--profile", help="AWS Profile", envvar="AWS_PROFILE")
+@click.option("--region", help="AWS Region", envvar="AWS_REGION")
 @click.pass_context
 @catch_exceptions
 def view_secret(
@@ -19,27 +22,27 @@ def view_secret(
     env_file: str,
     name: str,
     profile: Optional[str],
-    region: Optional[str]
+    region: Optional[str],
 ):
     """
-        View AWS Secrets Manager secret value CLI Commmand `aws-secrets view-parameter --help`
+    View AWS Secrets Manager secret value CLI Commmand `aws-secrets view-parameter --help`
 
-        Args:
-            ctx (`Context`): click context object
-            env_file (`str`): configuration YAML file
-            name (`str`): SSM parameter name
-            profile (`str`, optional): AWS Profile
-            region (`str`, optional): AWS Region
+    Args:
+        ctx (`Context`): click context object
+        env_file (`str`): configuration YAML file
+        name (`str`): SSM parameter name
+        profile (`str`, optional): AWS Profile
+        region (`str`, optional): AWS Region
     """
-    ctx.obj['config_file'] = env_file
+    ctx.obj["config_file"] = env_file
     session.aws_profile = profile
     session.aws_region = region
 
     config = ConfigReader(env_file)
-    provider = config.get_provider('secrets')
+    provider = config.get_provider("secrets")
     secret = provider.find(name)
 
     if secret is None:
-        raise CLIError(f'secret {name} not found')
+        raise CLIError(f"secret {name} not found")
 
-    click.echo(secret.decrypt())
+    click.echo(secret.decrypt(format=True))

--- a/aws_secrets/config/config_reader.py
+++ b/aws_secrets/config/config_reader.py
@@ -2,31 +2,31 @@ import os
 from pathlib import Path
 from typing import Any, Dict
 
-import yaml
-
 from aws_secrets.config.providers import BaseProvider
-from aws_secrets.config.providers.secretsmanager.provider import SecretsManagerProvider
+from aws_secrets.config.providers.secretsmanager.provider import \
+    SecretsManagerProvider
 from aws_secrets.config.providers.ssm.provider import SSMProvider
 from aws_secrets.miscellaneous import session
+from aws_secrets.yaml import yaml
 
 
 class ConfigReader(object):
     """
-        Config Reader handles the configuration and the secrets YAML files
+    Config Reader handles the configuration and the secrets YAML files
 
-        Also, abstract the encrypt/decrypt function using the Providers
+    Also, abstract the encrypt/decrypt function using the Providers
 
-        Args:
-            config_file (`str`): configuration file path
+    Args:
+        config_file (`str`): configuration file path
 
-        Attributes:
-            data (`Dict[str, Any]`): configuration parsed YAML
-            secrets_file_path (`str`): secrets YAML file path
-            global_tags (`Dict[str, str]`): map of global tags of the config file
-            secrets_data (`Dict[str, Any]`): secrets parsed YAML
-            session (`Session`): boto3 session object
-            kms_arn (`str`): Main Kms ARN
-            providers (`Dict[str, BaseProvider]`): providers map
+    Attributes:
+        data (`Dict[str, Any]`): configuration parsed YAML
+        secrets_file_path (`str`): secrets YAML file path
+        global_tags (`Dict[str, str]`): map of global tags of the config file
+        secrets_data (`Dict[str, Any]`): secrets parsed YAML
+        session (`Session`): boto3 session object
+        kms_arn (`str`): Main Kms ARN
+        providers (`Dict[str, BaseProvider]`): providers map
     """
 
     def __init__(self, config_file: str) -> None:
@@ -36,136 +36,142 @@ class ConfigReader(object):
         self.data = self.load_config()
         self.secrets_file_path = self._get_secrets_path()
 
-        self.global_tags = self.data['tags'] if 'tags' in self.data else {}
+        self.global_tags = self.data["tags"] if "tags" in self.data else {}
         self.secrets_data = self.load_secrets_config()
 
         self.session = session.session()
         self.kms_arn = self.get_kms_arn()
-        self.encryption_sdk = self.data.get('encryption_sdk', 'boto3')
+        self.encryption_sdk = self.data.get("encryption_sdk", "boto3")
 
         self.providers = self.load_providers()
 
     def get_provider(self, name: str) -> BaseProvider:
         """
-            Get provider by name
+        Get provider by name
 
-            Supported names:
-            - secrets
-            - parameters
+        Supported names:
+        - secrets
+        - parameters
 
-            Args:
-                name (`str`): provider name
+        Args:
+            name (`str`): provider name
 
-            Returns:
-                `BaseProvider`: provider object
+        Returns:
+            `BaseProvider`: provider object
         """
         return self.providers[name]
 
     def _get_secrets_path(self) -> str:
         """
-            Get Secret file path based on the environment file.
+        Get Secret file path based on the environment file.
 
-            Returns:
-                `str`: secrets YAML file path
+        Returns:
+            `str`: secrets YAML file path
         """
         config_file_path = Path(self.config_file)
         config_filename = config_file_path.stem
         config_dir = str(config_file_path.parent)
 
-        if 'secrets_file' not in self.data:
-            secrets_path = os.path.join(config_dir, f'{config_filename}.secrets.yaml')
-            self.data['secrets_file'] = secrets_path
+        if "secrets_file" not in self.data:
+            secrets_path = os.path.join(config_dir, f"{config_filename}.secrets.yaml")
+            self.data["secrets_file"] = secrets_path
             return secrets_path
         else:
-            return str(Path(os.path.join(config_dir, self.data['secrets_file'])).resolve())
+            return str(
+                Path(os.path.join(config_dir, self.data["secrets_file"])).resolve()
+            )
 
     def load_providers(self) -> Dict[str, BaseProvider]:
         """
-            Load providers
+        Load providers
 
-            Returns:
-                `Dict[str, BaseProvider]`: providers
+        Returns:
+            `Dict[str, BaseProvider]`: providers
         """
         providers = {
-            'secrets': SecretsManagerProvider(self),
-            'parameters': SSMProvider(self)
+            "secrets": SecretsManagerProvider(self),
+            "parameters": SSMProvider(self),
         }
 
         return providers
 
     def get_kms_arn(self) -> str:
         """
-            Get main KMS Arn
+        Get main KMS Arn
 
-            Returns:
-                `str`: KMS ARN
+        Returns:
+            `str`: KMS ARN
         """
-        return str(self.data['kms']['arn'])
+        return str(self.data["kms"]["arn"])
 
     def load_secrets_config(self) -> Dict[str, Any]:
         """
-            Load secrets.yaml file to a dict object
+        Load secrets.yaml file to a dict object
 
-            Returns:
-                `Dict[str, Any]`: secrets dict object
+        Returns:
+            `Dict[str, Any]`: secrets dict object
         """
         secrets_data = {}
 
         if os.path.exists(self.secrets_file_path):
-            with open(self.secrets_file_path, 'r') as secrets:
-                secrets_data = yaml.safe_load(secrets.read())
+            with open(self.secrets_file_path, "r") as secrets:
+                secrets_data = yaml.load(secrets.read())
 
         return secrets_data
 
     def load_config(self) -> Dict[str, Any]:
         """
-            Load config YAML file to a dict object
+        Load config YAML file to a dict object
 
-            Returns:
-                `Dict[str, Any]`: config dict object
+        Returns:
+            `Dict[str, Any]`: config dict object
         """
-        with open(self.config_file, 'r') as source:
-            data = yaml.safe_load(source.read())
+        with open(self.config_file, "r") as source:
+            data = yaml.load(source.read())
         return data
 
     def decrypt(self) -> None:
         """
-            Call decrypt function in all the providers
+        Call decrypt function in all the providers
         """
-        self.get_provider('secrets').decrypt()
-        self.get_provider('parameters').decrypt()
+        self.get_provider("secrets").decrypt()
+        self.get_provider("parameters").decrypt()
 
     def encrypt(self) -> None:
         """
-            Call encrypt function in all the providers and delete the `value` property from the secret entries
+        Call encrypt function in all the providers and delete the `value` property from the secret entries
         """
         self.secrets_data = {
-            'secrets': self.get_provider('secrets').encrypt(),
-            'parameters': self.get_provider('parameters').encrypt()
+            "secrets": self.get_provider("secrets").encrypt(),
+            "parameters": self.get_provider("parameters").encrypt(),
         }
 
         self._delete_plain_text_property()
 
     def _delete_plain_text_property(self) -> None:
         """
-            Delete `value` property from the secrets entries
+        Delete `value` property from the secrets entries
 
-            For AWS Secrets Manager all the entries
-            For AWS SSM Parameter all the parameter with `SecureString` type
+        For AWS Secrets Manager all the entries
+        For AWS SSM Parameter all the parameter with `SecureString` type
         """
-        all_sensetive_items = self.get_provider('secrets').get_sensible_entries() + \
-            self.get_provider('parameters').get_sensible_entries()
+        all_sensetive_items = (
+            self.get_provider("secrets").get_sensible_entries()
+            + self.get_provider("parameters").get_sensible_entries()
+        )
 
         for item in all_sensetive_items:
-            if 'value' in item and (isinstance(item['value'], str) or isinstance(item['value'], dict)):
-                del item['value']
+            if "value" in item and (
+                isinstance(item["value"], str) or isinstance(item["value"], dict)
+            ):
+                del item["value"]
 
     def save(self) -> None:
         """
-            Save config and secrets changes in the disk
+        Save config and secrets changes in the disk
         """
-        with open(self.config_file, 'w') as outfile:
-            yaml.safe_dump(self.data, outfile)
+        with open(self.config_file, "w") as outfile:
+            yaml.dump(self.data, outfile)
 
-        with open(self.secrets_file_path, 'w') as outfile:
-            yaml.safe_dump(self.secrets_data, outfile)
+        with open(self.secrets_file_path, "w") as outfile:
+            yaml.dump(self.secrets_data, outfile)

--- a/aws_secrets/config/providers/secretsmanager/entry.py
+++ b/aws_secrets/config/providers/secretsmanager/entry.py
@@ -75,8 +75,8 @@ class SecretManagerEntry(BaseEntry):
         self.logger.debug(f'Secret - {self.name} - Entry already encrypted')
         return self.cipher_text
 
-    def decrypt(self) -> str:
-        def _do_decrypt(value):
+    def _do_decrypt(self) -> str:
+        def _decrypt(value):
             self.logger.debug(f'Secret - {self.name} - Decrypting entry')
             if self.provider.encryption_sdk == 'boto3':
                 return kms.decrypt(self.session, value, self.kms_arn).decode('utf-8')
@@ -84,9 +84,9 @@ class SecretManagerEntry(BaseEntry):
                 return crypto.decrypt(self.session, value, self.kms_arn)
 
         if self.cipher_text:
-            return _do_decrypt(self.cipher_text)
+            return _decrypt(self.cipher_text)
         elif self.cipher_text is None and self.raw_value is not None and isinstance(self.raw_value, str):
-            return _do_decrypt(self.raw_value)
+            return _decrypt(self.raw_value)
 
         return self.raw_value
 

--- a/aws_secrets/config/providers/secretsmanager/provider.py
+++ b/aws_secrets/config/providers/secretsmanager/provider.py
@@ -4,30 +4,31 @@ from typing import Any, Dict, List, Optional
 import click
 
 from aws_secrets.config.providers import BaseProvider
-from aws_secrets.config.providers.secretsmanager.entry import SecretManagerEntry
+from aws_secrets.config.providers.secretsmanager.entry import \
+    SecretManagerEntry
 
 
 class SecretsManagerProvider(BaseProvider):
     """
-        AWS Secrets Manager Provider
+    AWS Secrets Manager Provider
 
-        This class handles the AWS Secrets Manager features:
-        - deploy the changes
-        - add new secrets
-        - update existing secrets
-        - decrypt/encrypt secrets
+    This class handles the AWS Secrets Manager features:
+    - deploy the changes
+    - add new secrets
+    - update existing secrets
+    - decrypt/encrypt secrets
 
-        Args:
-            config (`ConfigReader`): configuration file reader handler
+    Args:
+        config (`ConfigReader`): configuration file reader handler
 
-        Attributes:
-            logger (`Logger`): logger instance
-            global_tags (`Dict[str, str]`): map of global tags of the config file
-            session (`Session`): boto3 session object
-            kms_arn (`str`): Main Kms ARN
-            config_data (`Dict[str, Any]`): configuration parsed YAML
-            secrets_data (`Dict[str, Any]`): secrets parsed YAML
-            entries (`List[SecretManagerEntry]`): entries list
+    Attributes:
+        logger (`Logger`): logger instance
+        global_tags (`Dict[str, str]`): map of global tags of the config file
+        session (`Session`): boto3 session object
+        kms_arn (`str`): Main Kms ARN
+        config_data (`Dict[str, Any]`): configuration parsed YAML
+        secrets_data (`Dict[str, Any]`): secrets parsed YAML
+        entries (`List[SecretManagerEntry]`): entries list
     """
 
     def __init__(self, config) -> None:
@@ -35,16 +36,19 @@ class SecretsManagerProvider(BaseProvider):
 
     def load_entries(self) -> List[SecretManagerEntry]:
         """
-            the secrets entries
-            location: config YAML file `secrets` list property
+        the secrets entries
+        location: config YAML file `secrets` list property
 
-            Returns:
-                `List[SecretManagerEntry]`: list of entries
+        Returns:
+            `List[SecretManagerEntry]`: list of entries
         """
         result = []
-        self.logger.debug('Loading Secrets Manager entries')
+        self.logger.debug("Loading Secrets Manager entries")
         for param in self._get_data_entries():
-            secret_data = next((p for p in self._get_secrets_entries() if p['name'] == param['name']), {})
+            secret_data = next(
+                (p for p in self._get_secrets_entries() if p["name"] == param["name"]),
+                {},
+            )
 
             result.append(
                 SecretManagerEntry(
@@ -52,7 +56,7 @@ class SecretsManagerProvider(BaseProvider):
                     kms_arn=self.kms_arn,
                     data=param,
                     provider=self,
-                    cipher_text=secret_data.get('value', None),
+                    cipher_text=secret_data.get("value", None),
                 )
             )
 
@@ -60,11 +64,11 @@ class SecretsManagerProvider(BaseProvider):
 
     def decrypt(self) -> None:
         """
-            Decrypt all the secrets in the config file
+        Decrypt all the secrets in the config file
         """
-        self.logger.debug('Decrypting Secrets Manager entries')
+        self.logger.debug("Decrypting Secrets Manager entries")
         for item in self._get_data_entries():
-            item_obj = self.find(item['name'])
+            item_obj = self.find(item["name"])
             decrypted_value = item_obj.decrypt()
 
             try:
@@ -72,37 +76,34 @@ class SecretsManagerProvider(BaseProvider):
             except Exception:
                 pass
 
-            item['value'] = decrypted_value
+            item["value"] = decrypted_value
 
     def find(self, name: str) -> Optional[SecretManagerEntry]:
         """
-            Find an AWS Secret Manager secret by name
+        Find an AWS Secret Manager secret by name
 
-            Args:
-                name (`str`): entry name
+        Args:
+            name (`str`): entry name
 
-            Returns:
-                `SecretManagerEntry`, optional: secret object or None
+        Returns:
+            `SecretManagerEntry`, optional: secret object or None
         """
         self.logger.debug(f'Finding Secrets Manager entries by name "{name}"')
         return next((e for e in self.entries if e.name == name), None)
 
     def add(self, data: Dict[str, Any]) -> SecretManagerEntry:
         """
-            Add new AWS Secret Manager secret
+        Add new AWS Secret Manager secret
 
-            Args:
-                data (`Dict[str, Any]`): new secret data
+        Args:
+            data (`Dict[str, Any]`): new secret data
 
-            Returns:
-                `SecretManagerEntry`: secret object
+        Returns:
+            `SecretManagerEntry`: secret object
         """
         self.logger.debug(f'Add "{data["name"]}" Secrets Manager entry')
         entry = SecretManagerEntry(
-            session=self.session,
-            kms_arn=self.kms_arn,
-            provider=self,
-            data=data
+            session=self.session, kms_arn=self.kms_arn, provider=self, data=data
         )
         self.entries.append(entry)
         self._get_data_entries().append(data)
@@ -112,42 +113,36 @@ class SecretsManagerProvider(BaseProvider):
 
     def update(self, data: Dict[str, Any]) -> None:
         """
-            Update an existing secret
+        Update an existing secret
 
-            Args:
-                data (`Dict[str, Any]`): updated secret data
+        Args:
+            data (`Dict[str, Any]`): updated secret data
         """
         self.logger.debug(f'Updating "{data["name"]}" Secrets Manager entry')
 
         for idx, entry in enumerate(self.entries):
-            if entry.name == data['name']:
-                self.logger.debug('Updating entry in the entries list')
+            if entry.name == data["name"]:
+                self.logger.debug("Updating entry in the entries list")
                 self.entries[idx] = SecretManagerEntry(
-                    session=self.session,
-                    kms_arn=self.kms_arn,
-                    provider=self,
-                    data=data
+                    session=self.session, kms_arn=self.kms_arn, provider=self, data=data
                 )
 
         data_entries = self._get_data_entries()
         for idx, item_data in enumerate(data_entries):
-            if item_data['name'] == data['name']:
-                self.logger.debug('Updating entry data in the data entries list')
-                data_entries[idx] = data
+            if item_data["name"] == data["name"]:
+                self.logger.debug("Updating entry data in the data entries list")
+                data_entries[idx] = {**data_entries[idx], **data}
 
     def deploy(
-        self,
-        filter_pattern: Optional[str],
-        dry_run: bool,
-        confirm: bool
+        self, filter_pattern: Optional[str], dry_run: bool, confirm: bool
     ) -> None:
         """
-            Deploy all AWS Secrets Manager secrets changes
+        Deploy all AWS Secrets Manager secrets changes
 
-            Args:
-                filter_pattern (`Optional[str]`): resource filter pattern
-                dry_run: (`bool`): dry run flag, just calculate the changes, but not apply them.
-                confirm: (`bool`): CLI confirmation prompt for the changes.
+        Args:
+            filter_pattern (`Optional[str]`): resource filter pattern
+            dry_run: (`bool`): dry run flag, just calculate the changes, but not apply them.
+            confirm: (`bool`): CLI confirmation prompt for the changes.
         """
         click.echo("Loading AWS Secrets Manager changes...")
         any_changes = False
@@ -159,58 +154,57 @@ class SecretsManagerProvider(BaseProvider):
             click.echo("no changes required")
 
     def _deploy_secret(
-        self,
-        secret: SecretManagerEntry,
-        dry_run: bool,
-        confirm: bool
+        self, secret: SecretManagerEntry, dry_run: bool, confirm: bool
     ) -> bool:
         """
-            Deploy a secret changes
+        Deploy a secret changes
 
-            Args:
-                secret (`SecretManagerEntry`): Secret entry object
-                dry_run: (`bool`): dry run flag, just calculate the changes, but not apply them.
-                confirm: (`bool`): CLI confirmation prompt for the changes.
+        Args:
+            secret (`SecretManagerEntry`): Secret entry object
+            dry_run: (`bool`): dry run flag, just calculate the changes, but not apply them.
+            confirm: (`bool`): CLI confirmation prompt for the changes.
 
-            Returns:
-                `bool`: if changes are found.
+        Returns:
+            `bool`: if changes are found.
         """
         self.merge_tags(secret)
         changes = secret.changes()
 
-        if not changes['Exists']:
-            self.print_resource_name('Secret', secret.name)
+        if not changes["Exists"]:
+            self.print_resource_name("Secret", secret.name)
             click.echo("--> New Secret")
 
-            if (not dry_run and confirm and
-                    click.confirm("--> Would you to create this secret?")) or \
-                    (not dry_run and confirm is False):
+            if (
+                not dry_run
+                and confirm
+                and click.confirm("--> Would you to create this secret?")
+            ) or (not dry_run and confirm is False):
                 secret.create()
                 return True
         else:
-            if len(changes['ChangesList']) > 0:
+            if len(changes["ChangesList"]) > 0:
                 self._apply_secret_changes(secret, changes, dry_run, confirm)
                 return True
 
-        return changes['Exists'] is False or len(changes['ChangesList']) > 0
+        return changes["Exists"] is False or len(changes["ChangesList"]) > 0
 
     def _apply_secret_changes(
         self,
         secret: SecretManagerEntry,
         changes: Dict[str, Any],
         dry_run: bool,
-        confirm: bool
+        confirm: bool,
     ) -> None:
         """
-            Update an existing secret on the AWS environment
+        Update an existing secret on the AWS environment
 
-            Args:
-                secret (`SecretManagerEntry`): Secret entry object
-                changes (`Dict[str, Any]`): map of changes
-                dry_run: (`bool`): dry run flag, just calculate the changes, but not apply them.
-                confirm: (`bool`): CLI confirmation prompt for the changes.
+        Args:
+            secret (`SecretManagerEntry`): Secret entry object
+            changes (`Dict[str, Any]`): map of changes
+            dry_run: (`bool`): dry run flag, just calculate the changes, but not apply them.
+            confirm: (`bool`): CLI confirmation prompt for the changes.
         """
-        self.print_resource_name('Secret', secret.name)
+        self.print_resource_name("Secret", secret.name)
         self.print_changes(changes)
 
         if not dry_run:
@@ -220,33 +214,33 @@ class SecretsManagerProvider(BaseProvider):
 
     def get_sensible_entries(self) -> List[Dict[str, Any]]:
         """
-            Get sensible entries, in the AWS Secrets Manager case all the entries
+        Get sensible entries, in the AWS Secrets Manager case all the entries
 
-            Returns:
-                `List[Dict[str, Any]]`: list of sensible entries data
+        Returns:
+            `List[Dict[str, Any]]`: list of sensible entries data
         """
         return self._get_data_entries()
 
     def _get_secrets_entries(self) -> List[Dict[str, Any]]:
         """
-            Get secrets config file entries
+        Get secrets config file entries
 
-            Returns:
-                `List[Dict[str, Any]]`: list of secrets
+        Returns:
+            `List[Dict[str, Any]]`: list of secrets
         """
-        if 'secrets' not in self.secrets_data:
-            self.secrets_data['secrets'] = []
+        if "secrets" not in self.secrets_data:
+            self.secrets_data["secrets"] = []
 
-        return self.secrets_data.get('secrets', [])
+        return self.secrets_data.get("secrets", [])
 
     def _get_data_entries(self) -> List[Dict[str, Any]]:
         """
-            Get the parsed config YAML secrets
+        Get the parsed config YAML secrets
 
-            Returns:
-                `List[Dict[str, Any]]`: list of secrets
+        Returns:
+            `List[Dict[str, Any]]`: list of secrets
         """
-        if 'secrets' not in self.config_data:
-            self.config_data['secrets'] = []
+        if "secrets" not in self.config_data:
+            self.config_data["secrets"] = []
 
-        return self.config_data.get('secrets', [])
+        return self.config_data.get("secrets", [])

--- a/aws_secrets/config/providers/ssm/entry.py
+++ b/aws_secrets/config/providers/ssm/entry.py
@@ -82,8 +82,8 @@ class SSMParameterEntry(BaseEntry):
 
         return None
 
-    def decrypt(self) -> str:
-        def _do_decrypt(value):
+    def _do_decrypt(self) -> str:
+        def _decrypt(value):
             self.logger.debug(f'Parameter - {self.name} - Decrypting entry')
             if self.provider.encryption_sdk == 'boto3':
                 return kms.decrypt(self.session, value, self.kms_arn).decode('utf-8')
@@ -91,10 +91,10 @@ class SSMParameterEntry(BaseEntry):
                 return crypto.decrypt(self.session, value, self.kms_arn)
 
         if self.type == 'SecureString' and self.cipher_text:
-            return _do_decrypt(self.cipher_text)
+            return _decrypt(self.cipher_text)
         elif self.type == 'SecureString' and self.cipher_text is None \
                 and self.raw_value is not None and isinstance(self.raw_value, str):
-            return _do_decrypt(self.raw_value)
+            return _decrypt(self.raw_value)
 
         return self.raw_value
 

--- a/aws_secrets/config/providers/ssm/provider.py
+++ b/aws_secrets/config/providers/ssm/provider.py
@@ -130,7 +130,7 @@ class SSMProvider(BaseProvider):
         for idx, item_data in enumerate(data_entries):
             if item_data['name'] == data['name']:
                 self.logger.debug('Updating entry data in the data entries list')
-                data_entries[idx] = data
+                data_entries[idx] = {**item_data, **data}
 
     def deploy(
         self,

--- a/aws_secrets/miscellaneous/prompt.py
+++ b/aws_secrets/miscellaneous/prompt.py
@@ -1,0 +1,98 @@
+from __future__ import unicode_literals
+
+import sys
+from typing import Optional, Sequence, Tuple, Union
+
+from prompt_toolkit.application import Application
+from prompt_toolkit.formatted_text import AnyFormattedText
+from prompt_toolkit.key_binding.defaults import load_key_bindings
+from prompt_toolkit.key_binding.key_bindings import (KeyBindings,
+                                                     merge_key_bindings)
+from prompt_toolkit.layout import Layout
+from prompt_toolkit.layout.containers import HSplit
+from prompt_toolkit.styles import Style
+from prompt_toolkit.widgets import Label, RadioList
+
+DEFAULT_PROMPT_SYLE = Style.from_dict(
+    {
+        # Default style.
+        "": "#56B6C2",
+        "question": "ansigray",
+        "question_mark": "#98C379 bold",
+    }
+)
+
+
+def radiolist_prompt(
+    title: Union[str, AnyFormattedText] = "",
+    values: Sequence[Tuple[str, AnyFormattedText]] = None,
+    default: Optional[str] = None,
+    cancel_value: Optional[str] = None,
+    style: Optional[Style] = DEFAULT_PROMPT_SYLE,
+) -> str:
+    """
+    Custom prompt for selecting a value from a list of values.
+
+    Kudos to: https://github.com/prompt-toolkit/python-prompt-toolkit/issues/756#issuecomment-1294742392
+
+    Args:
+        title (`Union[str, AnyFormattedText]`): prompt title
+        values (`Sequence[Tuple[str, AnyFormattedText]]`): list of values to select from
+        default (`Optional[str]`): default value
+        cancel_value (`Optional[str]`): value to return if the user cancels the prompt
+        style (`Optional[Style]`): prompt style
+
+    Returns:
+        selected value
+    """
+    # Create the radio list
+    radio_list = RadioList(values, default)
+    # Remove the enter key binding so that we can augment it
+    radio_list.control.key_bindings.remove("enter")
+
+    bindings = KeyBindings()
+
+    # Replace the enter key binding to select the value and also submit it
+    @bindings.add("enter")
+    def exit_with_value(event):
+        """
+        Pressing Enter will exit the user interface, returning the highlighted value.
+        """
+        radio_list._handle_enter()
+        event.app.exit(result=radio_list.current_value)
+
+    @bindings.add("c-c")
+    def backup_exit_with_value(event):
+        """
+        Pressing Ctrl-C will exit the user interface with the cancel_value.
+        """
+        event.app.exit(result=cancel_value)
+
+    # Create and run the mini inline application
+    application = Application(
+        layout=Layout(HSplit([Label(title), radio_list])),
+        key_bindings=merge_key_bindings([load_key_bindings(), bindings]),
+        mouse_support=True,
+        style=style,
+        full_screen=False,
+    )
+
+    return application.run()
+
+
+def get_multiline_input_save_keyboard() -> str:
+    """
+    Based on the OS, return the keyboard key combination to save multiline input
+
+    Returns:
+        keyboard key combination
+    """
+    is_windows = sys.platform.startswith("win")
+    is_mac = sys.platform.startswith("darwin")
+
+    if is_windows:
+        return "[Windows+Enter]"
+    elif is_mac:
+        return "[Option+Enter]"
+
+    return "[Meta+Enter]"

--- a/aws_secrets/miscellaneous/session.py
+++ b/aws_secrets/miscellaneous/session.py
@@ -15,4 +15,4 @@ def session() -> Session:
             `Session`: boto3 session object
     """
     return boto3.session.Session(
-        region_name=aws_region, profile_name=aws_profile)
+        region_name=aws_region if aws_region else None, profile_name=aws_profile if aws_profile else None)

--- a/aws_secrets/representers/literal.py
+++ b/aws_secrets/representers/literal.py
@@ -1,22 +1,22 @@
-from yaml.dumper import SafeDumper
-from yaml.nodes import ScalarNode
+from ruamel.yaml.nodes import ScalarNode
+from ruamel.yaml.representer import SafeRepresenter
 
 
 class Literal(str):
     """
-        YAML Literal string representer
+    YAML Literal string representer
     """
 
 
-def literal_presenter(dumper: SafeDumper, data: str) -> ScalarNode:
+def literal_presenter(representer: SafeRepresenter, data: Literal) -> ScalarNode:
     """
-        YAML Literal presenter
+    YAML Literal presenter
 
-        Args:
-            dumper (`SafeDumper`): YAML safe dumper
-            data (`str`): raw value
+    Args:
+        representer (`SafeRepresenter`): YAML safe representer
+        data (`Literal`): raw value
 
-        Returns:
-            `ScalarNode` YAML scalar node
+    Returns:
+        `ScalarNode` YAML scalar node
     """
-    return dumper.represent_scalar('tag:yaml.org,2002:str', data, style='|')
+    return representer.represent_scalar("tag:yaml.org,2002:str", data, style="|")

--- a/aws_secrets/tags/file.py
+++ b/aws_secrets/tags/file.py
@@ -2,30 +2,30 @@ import logging
 import os
 
 import click
-import yaml
+from ruamel.yaml.constructor import ConstructorError
+from ruamel.yaml.nodes import ScalarNode
+
 from aws_secrets.helpers.catch_exceptions import CLIError
-from yaml.dumper import SafeDumper
-from yaml.nodes import ScalarNode
 
 
-class FileTag(yaml.YAMLObject):
+class FileTag:
     """
-        Custom YAML tag class
-        !file tag read the content from a file
+    Custom YAML tag class
+    !file tag read the content from a file
 
-        Examples:
-            >>> !file /path/file.txt
-            value: `'hello'`
+    Examples:
+        >>> !file /path/file.txt
+        value: `'hello'`
 
-        Args:
-            value (`str`): file path
+    Args:
+        value (`str`): file path
 
-        Attributes:
-            value (`str`): file path
-            logger (`Logger`): logger instance
+    Attributes:
+        value (`str`): file path
+        logger (`Logger`): logger instance
     """
 
-    yaml_tag = u'!file'
+    yaml_tag = "!file"
 
     def __init__(self, value: str):
         self.value = value
@@ -33,30 +33,32 @@ class FileTag(yaml.YAMLObject):
 
     def __repr__(self) -> str:
         """
-            Resolve the file path and read the content
+        Resolve the file path and read the content
 
-            Returns:
-                `str` file content
+        Returns:
+            `str` file content
         """
         click_ctx = click.get_current_context(silent=True)
         working_dir = os.getcwd()
 
         if click_ctx:
-            config_file = click_ctx.obj.get('config_file', '')
+            config_file = click_ctx.obj.get("config_file", "")
             working_dir = os.path.dirname(config_file)
 
         source_file_path = os.path.join(working_dir, self.value)
 
         if os.path.exists(source_file_path):
-            with open(source_file_path, 'r') as source:
+            with open(source_file_path, "r") as source:
                 return source.read()
         else:
             raise CLIError(f"File '{source_file_path}' not found")
 
     @classmethod
-    def from_yaml(cls, _, node):
-        return FileTag(node.value)
+    def from_yaml(cls, constructor, node):
+        if isinstance(node, ScalarNode):
+            return cls(node.value)
+        raise ConstructorError(f"Error constructing YAML {cls.yaml_tag}")
 
     @classmethod
-    def to_yaml(cls, dumper: SafeDumper, data) -> ScalarNode:
-        return dumper.represent_scalar(cls.yaml_tag, data.value)
+    def to_yaml(cls, representer, data):
+        return representer.represent_scalar(cls.yaml_tag, data.value)

--- a/aws_secrets/tags/output_stack.py
+++ b/aws_secrets/tags/output_stack.py
@@ -1,46 +1,46 @@
-import yaml
-from yaml.dumper import SafeDumper
-from yaml.nodes import ScalarNode
+from ruamel.yaml.constructor import ConstructorError
+from ruamel.yaml.nodes import ScalarNode
 
 from aws_secrets.helpers.catch_exceptions import CLIError
 from aws_secrets.miscellaneous import cloudformation, session
 
 
-class OutputStackTag(yaml.YAMLObject):
+class OutputStackTag:
     """
-        Custom YAML tag class
-        !cf_output tag calls the boto3 cloudformation get outputs API and resolve the output value
+    Custom YAML tag class
+    !cf_output tag calls the boto3 cloudformation get outputs API and resolve the output value
 
-        Examples:
-            >>> !cf_output <stack>.<output-name>
-            >>> !cf_output <stack>.<output-name>.<aws-region>
-            value: <stack-output-value>
+    Examples:
+        >>> !cf_output <stack>.<output-name>
+        >>> !cf_output <stack>.<output-name>.<aws-region>
+        value: <stack-output-value>
 
-        Args:
-            value (`str`): value after `!cf_output` tag (e.g `!cf_output some` the value will be `some`)
+    Args:
+        value (`str`): value after `!cf_output` tag (e.g `!cf_output some` the value will be `some`)
 
-        Attributes:
-            value (`str`): value after `!cf_output` tag (e.g `!cf_output some` the value will be `some`)
+    Attributes:
+        value (`str`): value after `!cf_output` tag (e.g `!cf_output some` the value will be `some`)
     """
-    yaml_tag = u'!cf_output'
+
+    yaml_tag = "!cf_output"
 
     def __init__(self, value: str):
         self.stack = value
 
     def __repr__(self) -> str:
         """
-            Resolve the CloudFormation stack ouput value
+        Resolve the CloudFormation stack output value
 
-            Returns:
-                `str`: stack output value
+        Returns:
+            `str`: stack output value
         """
-        stack_args = self.stack.split('.')
+        stack_args = self.stack.split(".")
         if len(stack_args) < 2 or len(stack_args) > 3:
             raise CLIError(
                 (
-                    f'value {self.stack} is invalid, the correct way to '
-                    'fill this information is <stack-name>.<output-name> '
-                    'or <stack-name>.<output-name>.<aws_region>'
+                    f"value {self.stack} is invalid, the correct way to "
+                    "fill this information is <stack-name>.<output-name> "
+                    "or <stack-name>.<output-name>.<aws_region>"
                 )
             )
         region = None
@@ -52,12 +52,16 @@ class OutputStackTag(yaml.YAMLObject):
         except IndexError:
             pass
 
-        return cloudformation.get_output_value(session.session(), stack_name, output_name)
+        return cloudformation.get_output_value(
+            session.session(), stack_name, output_name
+        )
 
     @classmethod
-    def from_yaml(cls, _, node):
-        return OutputStackTag(node.value)
+    def from_yaml(cls, constructor, node):
+        if isinstance(node, ScalarNode):
+            return cls(node.value)
+        raise ConstructorError(f"Error constructing YAML {cls.yaml_tag}")
 
     @classmethod
-    def to_yaml(cls, dumper: SafeDumper, data) -> ScalarNode:
-        return dumper.represent_scalar(cls.yaml_tag, data.stack)
+    def to_yaml(cls, representer, data):
+        return representer.represent_scalar(cls.yaml_tag, data.stack)

--- a/aws_secrets/yaml.py
+++ b/aws_secrets/yaml.py
@@ -1,0 +1,14 @@
+from ruamel.yaml import YAML
+
+from aws_secrets.representers.literal import Literal, literal_presenter
+from aws_secrets.tags.cmd import CmdTag
+from aws_secrets.tags.file import FileTag
+from aws_secrets.tags.output_stack import OutputStackTag
+
+yaml = YAML()
+
+yaml.indent(mapping=2, sequence=4, offset=2)
+yaml.register_class(CmdTag)
+yaml.register_class(FileTag)
+yaml.register_class(OutputStackTag)
+yaml.representer.add_representer(Literal, literal_presenter)

--- a/poetry.lock
+++ b/poetry.lock
@@ -698,6 +698,16 @@ files = [
     {file = "MarkupSafe-2.1.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:5bbe06f8eeafd38e5d0a4894ffec89378b6c6a625ff57e3028921f8ff59318ac"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win32.whl", hash = "sha256:dd15ff04ffd7e05ffcb7fe79f1b98041b8ea30ae9234aed2a9168b5797c3effb"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win_amd64.whl", hash = "sha256:134da1eca9ec0ae528110ccc9e48041e0828d79f24121a1a146161103c76e686"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:f698de3fd0c4e6972b92290a45bd9b1536bffe8c6759c62471efaa8acb4c37bc"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:aa57bd9cf8ae831a362185ee444e15a93ecb2e344c8e52e4d721ea3ab6ef1823"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffcc3f7c66b5f5b7931a5aa68fc9cecc51e685ef90282f4a82f0f5e9b704ad11"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47d4f1c5f80fc62fdd7777d0d40a2e9dda0a05883ab11374334f6c4de38adffd"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1f67c7038d560d92149c060157d623c542173016c4babc0c1913cca0564b9939"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:9aad3c1755095ce347e26488214ef77e0485a3c34a50c5a5e2471dff60b9dd9c"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:14ff806850827afd6b07a5f32bd917fb7f45b046ba40c57abdb636674a8b559c"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8f9293864fe09b8149f0cc42ce56e3f0e54de883a9de90cd427f191c346eb2e1"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-win32.whl", hash = "sha256:715d3562f79d540f251b99ebd6d8baa547118974341db04f5ad06d5ea3eb8007"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-win_amd64.whl", hash = "sha256:1b8dd8c3fd14349433c79fa8abeb573a55fc0fdd769133baac1f5e07abf54aeb"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8e254ae696c88d98da6555f5ace2279cf7cd5b3f52be2b5cf97feafe883b58d2"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb0932dc158471523c9637e807d9bfb93e06a95cbf010f1a38b98623b929ef2b"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9402b03f1a1b4dc4c19845e5c749e3ab82d5078d16a2a4c2cd2df62d57bb0707"},
@@ -830,13 +840,13 @@ virtualenv = ">=20.10.0"
 
 [[package]]
 name = "prompt-toolkit"
-version = "3.0.39"
+version = "3.0.47"
 description = "Library for building powerful interactive command lines in Python"
 optional = false
 python-versions = ">=3.7.0"
 files = [
-    {file = "prompt_toolkit-3.0.39-py3-none-any.whl", hash = "sha256:9dffbe1d8acf91e3de75f3b544e4842382fc06c6babe903ac9acb74dc6e08d88"},
-    {file = "prompt_toolkit-3.0.39.tar.gz", hash = "sha256:04505ade687dc26dc4284b1ad19a83be2f2afe83e7a828ace0c72f3a1df72aac"},
+    {file = "prompt_toolkit-3.0.47-py3-none-any.whl", hash = "sha256:0d7bfa67001d5e39d02c224b663abc33687405033a8c422d0d675a5a13361d10"},
+    {file = "prompt_toolkit-3.0.47.tar.gz", hash = "sha256:1e1b29cb58080b1e69f207c893a1a7bf16d127a5c30c9d17a25a5d77792e5360"},
 ]
 
 [package.dependencies]
@@ -1143,6 +1153,7 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -1247,6 +1258,83 @@ typing-extensions = {version = ">=4.0.0,<5.0", markers = "python_version < \"3.9
 
 [package.extras]
 jupyter = ["ipywidgets (>=7.5.1,<9)"]
+
+[[package]]
+name = "ruamel-yaml"
+version = "0.18.6"
+description = "ruamel.yaml is a YAML parser/emitter that supports roundtrip preservation of comments, seq/map flow style, and map key order"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ruamel.yaml-0.18.6-py3-none-any.whl", hash = "sha256:57b53ba33def16c4f3d807c0ccbc00f8a6081827e81ba2491691b76882d0c636"},
+    {file = "ruamel.yaml-0.18.6.tar.gz", hash = "sha256:8b27e6a217e786c6fbe5634d8f3f11bc63e0f80f6a5890f28863d9c45aac311b"},
+]
+
+[package.dependencies]
+"ruamel.yaml.clib" = {version = ">=0.2.7", markers = "platform_python_implementation == \"CPython\" and python_version < \"3.13\""}
+
+[package.extras]
+docs = ["mercurial (>5.7)", "ryd"]
+jinja2 = ["ruamel.yaml.jinja2 (>=0.2)"]
+
+[[package]]
+name = "ruamel-yaml-clib"
+version = "0.2.8"
+description = "C version of reader, parser and emitter for ruamel.yaml derived from libyaml"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b42169467c42b692c19cf539c38d4602069d8c1505e97b86387fcf7afb766e1d"},
+    {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:07238db9cbdf8fc1e9de2489a4f68474e70dffcb32232db7c08fa61ca0c7c462"},
+    {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:fff3573c2db359f091e1589c3d7c5fc2f86f5bdb6f24252c2d8e539d4e45f412"},
+    {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-manylinux_2_24_aarch64.whl", hash = "sha256:aa2267c6a303eb483de8d02db2871afb5c5fc15618d894300b88958f729ad74f"},
+    {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:840f0c7f194986a63d2c2465ca63af8ccbbc90ab1c6001b1978f05119b5e7334"},
+    {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:024cfe1fc7c7f4e1aff4a81e718109e13409767e4f871443cbff3dba3578203d"},
+    {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-win32.whl", hash = "sha256:c69212f63169ec1cfc9bb44723bf2917cbbd8f6191a00ef3410f5a7fe300722d"},
+    {file = "ruamel.yaml.clib-0.2.8-cp310-cp310-win_amd64.whl", hash = "sha256:cabddb8d8ead485e255fe80429f833172b4cadf99274db39abc080e068cbcc31"},
+    {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:bef08cd86169d9eafb3ccb0a39edb11d8e25f3dae2b28f5c52fd997521133069"},
+    {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:b16420e621d26fdfa949a8b4b47ade8810c56002f5389970db4ddda51dbff248"},
+    {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:25c515e350e5b739842fc3228d662413ef28f295791af5e5110b543cf0b57d9b"},
+    {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-manylinux_2_24_aarch64.whl", hash = "sha256:1707814f0d9791df063f8c19bb51b0d1278b8e9a2353abbb676c2f685dee6afe"},
+    {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:46d378daaac94f454b3a0e3d8d78cafd78a026b1d71443f4966c696b48a6d899"},
+    {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:09b055c05697b38ecacb7ac50bdab2240bfca1a0c4872b0fd309bb07dc9aa3a9"},
+    {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-win32.whl", hash = "sha256:53a300ed9cea38cf5a2a9b069058137c2ca1ce658a874b79baceb8f892f915a7"},
+    {file = "ruamel.yaml.clib-0.2.8-cp311-cp311-win_amd64.whl", hash = "sha256:c2a72e9109ea74e511e29032f3b670835f8a59bbdc9ce692c5b4ed91ccf1eedb"},
+    {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:ebc06178e8821efc9692ea7544aa5644217358490145629914d8020042c24aa1"},
+    {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:edaef1c1200c4b4cb914583150dcaa3bc30e592e907c01117c08b13a07255ec2"},
+    {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d176b57452ab5b7028ac47e7b3cf644bcfdc8cacfecf7e71759f7f51a59e5c92"},
+    {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-manylinux_2_24_aarch64.whl", hash = "sha256:1dc67314e7e1086c9fdf2680b7b6c2be1c0d8e3a8279f2e993ca2a7545fecf62"},
+    {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:3213ece08ea033eb159ac52ae052a4899b56ecc124bb80020d9bbceeb50258e9"},
+    {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:aab7fd643f71d7946f2ee58cc88c9b7bfc97debd71dcc93e03e2d174628e7e2d"},
+    {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-win32.whl", hash = "sha256:5c365d91c88390c8d0a8545df0b5857172824b1c604e867161e6b3d59a827eaa"},
+    {file = "ruamel.yaml.clib-0.2.8-cp312-cp312-win_amd64.whl", hash = "sha256:1758ce7d8e1a29d23de54a16ae867abd370f01b5a69e1a3ba75223eaa3ca1a1b"},
+    {file = "ruamel.yaml.clib-0.2.8-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:a5aa27bad2bb83670b71683aae140a1f52b0857a2deff56ad3f6c13a017a26ed"},
+    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c58ecd827313af6864893e7af0a3bb85fd529f862b6adbefe14643947cfe2942"},
+    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-macosx_12_0_arm64.whl", hash = "sha256:f481f16baec5290e45aebdc2a5168ebc6d35189ae6fea7a58787613a25f6e875"},
+    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-manylinux_2_24_aarch64.whl", hash = "sha256:77159f5d5b5c14f7c34073862a6b7d34944075d9f93e681638f6d753606c6ce6"},
+    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:7f67a1ee819dc4562d444bbafb135832b0b909f81cc90f7aa00260968c9ca1b3"},
+    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:4ecbf9c3e19f9562c7fdd462e8d18dd902a47ca046a2e64dba80699f0b6c09b7"},
+    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:87ea5ff66d8064301a154b3933ae406b0863402a799b16e4a1d24d9fbbcbe0d3"},
+    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-win32.whl", hash = "sha256:75e1ed13e1f9de23c5607fe6bd1aeaae21e523b32d83bb33918245361e9cc51b"},
+    {file = "ruamel.yaml.clib-0.2.8-cp37-cp37m-win_amd64.whl", hash = "sha256:3f215c5daf6a9d7bbed4a0a4f760f3113b10e82ff4c5c44bec20a68c8014f675"},
+    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1b617618914cb00bf5c34d4357c37aa15183fa229b24767259657746c9077615"},
+    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-macosx_12_0_arm64.whl", hash = "sha256:a6a9ffd280b71ad062eae53ac1659ad86a17f59a0fdc7699fd9be40525153337"},
+    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-manylinux_2_24_aarch64.whl", hash = "sha256:305889baa4043a09e5b76f8e2a51d4ffba44259f6b4c72dec8ca56207d9c6fe1"},
+    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:700e4ebb569e59e16a976857c8798aee258dceac7c7d6b50cab63e080058df91"},
+    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:e2b4c44b60eadec492926a7270abb100ef9f72798e18743939bdbf037aab8c28"},
+    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:e79e5db08739731b0ce4850bed599235d601701d5694c36570a99a0c5ca41a9d"},
+    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-win32.whl", hash = "sha256:955eae71ac26c1ab35924203fda6220f84dce57d6d7884f189743e2abe3a9fbe"},
+    {file = "ruamel.yaml.clib-0.2.8-cp38-cp38-win_amd64.whl", hash = "sha256:56f4252222c067b4ce51ae12cbac231bce32aee1d33fbfc9d17e5b8d6966c312"},
+    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:03d1162b6d1df1caa3a4bd27aa51ce17c9afc2046c31b0ad60a0a96ec22f8001"},
+    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:bba64af9fa9cebe325a62fa398760f5c7206b215201b0ec825005f1b18b9bccf"},
+    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-manylinux_2_24_aarch64.whl", hash = "sha256:a1a45e0bb052edf6a1d3a93baef85319733a888363938e1fc9924cb00c8df24c"},
+    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:da09ad1c359a728e112d60116f626cc9f29730ff3e0e7db72b9a2dbc2e4beed5"},
+    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:184565012b60405d93838167f425713180b949e9d8dd0bbc7b49f074407c5a8b"},
+    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a75879bacf2c987c003368cf14bed0ffe99e8e85acfa6c0bfffc21a090f16880"},
+    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-win32.whl", hash = "sha256:84b554931e932c46f94ab306913ad7e11bba988104c5cff26d90d03f68258cd5"},
+    {file = "ruamel.yaml.clib-0.2.8-cp39-cp39-win_amd64.whl", hash = "sha256:25ac8c08322002b06fa1d49d1646181f0b2c72f5cbc15a85e80b4c30a544bb15"},
+    {file = "ruamel.yaml.clib-0.2.8.tar.gz", hash = "sha256:beb2e0404003de9a4cab9753a8805a8fe9320ee6673136ed7f04255fe60bb512"},
+]
 
 [[package]]
 name = "s3transfer"
@@ -1445,6 +1533,16 @@ files = [
     {file = "wrapt-1.14.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8ad85f7f4e20964db4daadcab70b47ab05c7c1cf2a7c1e51087bfaa83831854c"},
     {file = "wrapt-1.14.1-cp310-cp310-win32.whl", hash = "sha256:a9a52172be0b5aae932bef82a79ec0a0ce87288c7d132946d645eba03f0ad8a8"},
     {file = "wrapt-1.14.1-cp310-cp310-win_amd64.whl", hash = "sha256:6d323e1554b3d22cfc03cd3243b5bb815a51f5249fdcbb86fda4bf62bab9e164"},
+    {file = "wrapt-1.14.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ecee4132c6cd2ce5308e21672015ddfed1ff975ad0ac8d27168ea82e71413f55"},
+    {file = "wrapt-1.14.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2020f391008ef874c6d9e208b24f28e31bcb85ccff4f335f15a3251d222b92d9"},
+    {file = "wrapt-1.14.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2feecf86e1f7a86517cab34ae6c2f081fd2d0dac860cb0c0ded96d799d20b335"},
+    {file = "wrapt-1.14.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:240b1686f38ae665d1b15475966fe0472f78e71b1b4903c143a842659c8e4cb9"},
+    {file = "wrapt-1.14.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a9008dad07d71f68487c91e96579c8567c98ca4c3881b9b113bc7b33e9fd78b8"},
+    {file = "wrapt-1.14.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:6447e9f3ba72f8e2b985a1da758767698efa72723d5b59accefd716e9e8272bf"},
+    {file = "wrapt-1.14.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:acae32e13a4153809db37405f5eba5bac5fbe2e2ba61ab227926a22901051c0a"},
+    {file = "wrapt-1.14.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:49ef582b7a1152ae2766557f0550a9fcbf7bbd76f43fbdc94dd3bf07cc7168be"},
+    {file = "wrapt-1.14.1-cp311-cp311-win32.whl", hash = "sha256:358fe87cc899c6bb0ddc185bf3dbfa4ba646f05b1b0b9b5a27c2cb92c2cea204"},
+    {file = "wrapt-1.14.1-cp311-cp311-win_amd64.whl", hash = "sha256:26046cd03936ae745a502abf44dac702a5e6880b2b01c29aea8ddf3353b68224"},
     {file = "wrapt-1.14.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:43ca3bbbe97af00f49efb06e352eae40434ca9d915906f77def219b88e85d907"},
     {file = "wrapt-1.14.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:6b1a564e6cb69922c7fe3a678b9f9a3c54e72b469875aa8018f18b4d1dd1adf3"},
     {file = "wrapt-1.14.1-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:00b6d4ea20a906c0ca56d84f93065b398ab74b927a7a3dbd470f6fc503f95dc3"},
@@ -1510,4 +1608,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<4.0"
-content-hash = "e151530172d7041ae524e2298683a852544ab1f4e5b04afcdd544d6959ed40ea"
+content-hash = "f17e125bfcb576541d3b54cd0632e835b023981882a5ffa8c30055da6579b91b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,9 +35,10 @@ aws-secrets = "aws_secrets.cli.cli:cli"
 python = ">=3.8.1,<4.0"
 boto3 = "^1.3"
 click = "^8.1.7"
-PyYaml = "^6.0.1"
 jsonschema = "^3.2.0"
 aws-encryption-sdk = "^3.0.0"
+prompt-toolkit = "^3.0.47"
+ruamel-yaml = "^0.18.6"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.1"

--- a/tests/cli/test_decrypt.py
+++ b/tests/cli/test_decrypt.py
@@ -24,23 +24,29 @@ def test_decrypt_cli(
 
     original_config = f"""kms:
   arn: {KEY_ARN}
+# This is a comment
 parameters:
-- name: ssm1
-  type: SecureString
-- name: ssm2
-  type: String
-  value: PlainText2
-- name: ssm3
-  type: String
-  value: !cmd 'value'
-- name: ssm4
-  type: SecureString
-  value: !cmd 'value'
+  - name: ssm1
+    # This is a comment2
+    type: SecureString
+  - name: ssm2
+    type: String
+    value: PlainText2
+  - name: ssm3
+    type: String
+    value: !cmd 'echo "value"'
+  - name: ssm4
+    type: SecureString
+    value: !cmd 'echo "value"'
+
 secrets:
-- name: secret1
-- name: secret2
-  value: !cmd 'value'
+  - name: secret1
+  - name: secret2
+    value: !cmd 'echo "value"'
+
 secrets_file: ./config.secrets.yaml
+
+# This is a comment
 """
 
     original_secrets = """parameters:
@@ -75,23 +81,29 @@ secrets:
         with open(output_file, 'r') as config:
             assert config.read() == f"""kms:
   arn: {KEY_ARN}
+# This is a comment
 parameters:
-- name: ssm1
-  type: SecureString
-  value: PlainText
-- name: ssm2
-  type: String
-  value: PlainText2
-- name: ssm3
-  type: String
-  value: !cmd 'value'
-- name: ssm4
-  type: SecureString
-  value: !cmd 'value'
+  - name: ssm1
+    # This is a comment2
+    type: SecureString
+    value: PlainText
+  - name: ssm2
+    type: String
+    value: PlainText2
+  - name: ssm3
+    type: String
+    value: !cmd echo "value"
+  - name: ssm4
+    type: SecureString
+    value: !cmd echo "value"
+
 secrets:
-- name: secret1
-  value: PlainText
-- name: secret2
-  value: !cmd 'value'
+  - name: secret1
+    value: PlainText
+  - name: secret2
+    value: !cmd echo "value"
+
 secrets_file: ./config.secrets.yaml
+
+# This is a comment
 """

--- a/tests/cli/test_encrypt.py
+++ b/tests/cli/test_encrypt.py
@@ -34,15 +34,15 @@ parameters:
       value: PlainText2
     - name: ssm3
       type: String
-      value: !cmd "value"
+      value: !cmd 'echo "value"'
     - name: ssm4
       type: SecureString
-      value: !cmd "value"
+      value: !cmd 'echo "value"'
 secrets:
     - name: secret1
       value: PlainText
     - name: secret2
-      value: !cmd "value"
+      value: !cmd 'echo "value"'
 """)
 
         result = mock_cli_runner.invoke(cli, [
@@ -56,29 +56,30 @@ secrets:
             assert config.read() == f"""kms:
   arn: {KEY_ARN}
 parameters:
-- name: ssm1
-  type: SecureString
-- name: ssm2
-  type: String
-  value: PlainText2
-- name: ssm3
-  type: String
-  value: !cmd 'value'
-- name: ssm4
-  type: SecureString
-  value: !cmd 'value'
+  - name: ssm1
+    type: SecureString
+  - name: ssm2
+    type: String
+    value: PlainText2
+  - name: ssm3
+    type: String
+    value: !cmd echo "value"
+  - name: ssm4
+    type: SecureString
+    value: !cmd echo "value"
 secrets:
-- name: secret1
-- name: secret2
-  value: !cmd 'value'
+  - name: secret1
+  - name: secret2
+    value: !cmd echo "value"
 secrets_file: ./config.secrets.yaml
 """
 
         with open('config.secrets.yaml', 'r') as secrets:
-            assert secrets.read() == """parameters:
-- name: ssm1
-  value: SecretData
+            assert secrets.read() == """\
 secrets:
-- name: secret1
-  value: SecretData
+  - name: secret1
+    value: SecretData
+parameters:
+  - name: ssm1
+    value: SecretData
 """

--- a/tests/cli/test_set_secret.py
+++ b/tests/cli/test_set_secret.py
@@ -2,391 +2,535 @@ from unittest.mock import ANY, patch
 
 from aws_secrets.cli.cli import cli
 
-KEY_ARN = 'arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab'
-KEY_ARN1 = 'arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab1'
-
-input_captured = False
-input_value = "PlainText"
-
-
-def _mock_input():
-    global input_captured
-
-    if input_captured is False:
-        input_captured = True
-        return input_value
-    else:
-        raise EOFError('')
+KEY_ARN = "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
+KEY_ARN1 = (
+    "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab1"
+)
 
 
-@patch('aws_secrets.miscellaneous.kms.encrypt')
-def test_set_secret_cli(
-    mock_encrypt,
-    mock_cli_runner,
-    monkeypatch
-):
+@patch("aws_secrets.miscellaneous.kms.encrypt")
+@patch("aws_secrets.cli.set_secret.prompt")
+def test_set_secret_cli_no_props(mock_prompt, mock_encrypt, mock_cli_runner):
     """
-        Should add a new secret
+    Should add a new secret
     """
-    global input_captured
-    input_captured = False
-    monkeypatch.setattr('builtins.input', _mock_input)
+    mock_prompt.side_effect = ["secret3", "Desc", "PlainText"]
 
-    mock_encrypt.return_value = b'SecretData'
-    config_file = 'config.yaml'
-    secrets_file = 'config.secrets.yaml'
+    mock_encrypt.return_value = b"SecretData"
+    config_file = "config.yaml"
+    secrets_file = "config.secrets.yaml"
 
     with mock_cli_runner.isolated_filesystem():
-        with open(config_file, 'w') as config:
-            config.write(f"""kms:
+        with open(config_file, "w") as config:
+            config.write(f"""\
+kms:
   arn: {KEY_ARN}
 parameters:
-- name: ssm1
-  type: SecureString
-- name: ssm2
-  type: String
-  value: PlainText2
-- name: ssm3
-  type: String
-  value: !cmd 'value'
-- name: ssm4
-  type: SecureString
-  value: !cmd 'value'
+  - name: ssm1
+    type: SecureString
+  - name: ssm2
+    type: String
+    value: PlainText2
+  - name: ssm3
+    type: String
+    value: !cmd value
+  - name: ssm4
+    type: SecureString
+    value: !cmd value
 secrets:
-- name: secret1
-- name: secret2
-  value: !cmd 'value'
+  - name: secret1
+  - name: secret2
+    value: !cmd value
 secrets_file: ./config.secrets.yaml
 """)
-        with open(secrets_file, 'w') as secrets:
-            secrets.write("""parameters:
-- name: ssm1
-  value: SecretData
+        with open(secrets_file, "w") as secrets:
+            secrets.write("""\
+parameters:
+  - name: ssm1
+    value: SecretData
 secrets:
-- name: secret1
-  value: SecretData
+  - name: secret1
+    value: SecretData
 """)
 
-        result = mock_cli_runner.invoke(cli, [
-            '--loglevel', "DEBUG",
-            'set-secret',
-            '--env-file', config_file,
-            '--name', 'secret3'
-        ])
+        result = mock_cli_runner.invoke(
+            cli,
+            [
+                "--loglevel",
+                "DEBUG",
+                "set-secret",
+                "--env-file",
+                config_file,
+            ],
+        )
 
         assert result.exit_code == 0
 
-        with open(config_file, 'r') as config:
-            assert config.read() == f"""kms:
+        with open(config_file, "r") as config:
+            assert (
+                config.read()
+                == f"""kms:
   arn: {KEY_ARN}
 parameters:
-- name: ssm1
-  type: SecureString
-- name: ssm2
-  type: String
-  value: PlainText2
-- name: ssm3
-  type: String
-  value: !cmd 'value'
-- name: ssm4
-  type: SecureString
-  value: !cmd 'value'
+  - name: ssm1
+    type: SecureString
+  - name: ssm2
+    type: String
+    value: PlainText2
+  - name: ssm3
+    type: String
+    value: !cmd value
+  - name: ssm4
+    type: SecureString
+    value: !cmd value
 secrets:
-- name: secret1
-- name: secret2
-  value: !cmd 'value'
-- name: secret3
+  - name: secret1
+  - name: secret2
+    value: !cmd value
+  - name: secret3
+    description: Desc
 secrets_file: ./config.secrets.yaml
 """
+            )
 
-        with open(secrets_file, 'r') as secrets:
-            assert secrets.read() == """parameters:
-- name: ssm1
-  value: SecretData
+        with open(secrets_file, "r") as secrets:
+            assert (
+                secrets.read()
+                == """\
 secrets:
-- name: secret1
-  value: SecretData
-- name: secret3
-  value: SecretData
+  - name: secret1
+    value: SecretData
+  - name: secret3
+    value: SecretData
+parameters:
+  - name: ssm1
+    value: SecretData
 """
-        mock_encrypt.assert_called_once_with(ANY, input_value, KEY_ARN)
+            )
+        mock_encrypt.assert_called_once_with(ANY, "PlainText", KEY_ARN)
 
 
-@patch('aws_secrets.miscellaneous.kms.encrypt')
-def test_set_secret_cli_with_description(
-    mock_encrypt,
-    mock_cli_runner,
-    monkeypatch
-):
+@patch("aws_secrets.miscellaneous.kms.encrypt")
+@patch("aws_secrets.cli.set_secret.prompt")
+def test_set_secret_cli(mock_prompt, mock_encrypt, mock_cli_runner):
     """
-        Should add a new secret with `--description`
+    Should add a new secret
     """
-    global input_captured
-    input_captured = False
-    monkeypatch.setattr('builtins.input', _mock_input)
+    mock_prompt.side_effect = ["Desc", "PlainText"]
 
-    mock_encrypt.return_value = b'SecretData'
-    config_file = 'config.yaml'
-    secrets_file = 'config.secrets.yaml'
+    mock_encrypt.return_value = b"SecretData"
+    config_file = "config.yaml"
+    secrets_file = "config.secrets.yaml"
 
     with mock_cli_runner.isolated_filesystem():
-        with open(config_file, 'w') as config:
-            config.write(f"""kms:
+        with open(config_file, "w") as config:
+            config.write(f"""\
+kms:
   arn: {KEY_ARN}
 parameters:
-- name: ssm1
-  type: SecureString
-- name: ssm2
-  type: String
-  value: PlainText2
-- name: ssm3
-  type: String
-  value: !cmd 'value'
-- name: ssm4
-  type: SecureString
-  value: !cmd 'value'
+  - name: ssm1
+    type: SecureString
+  - name: ssm2
+    type: String
+    value: PlainText2
+  - name: ssm3
+    type: String
+    value: !cmd value
+  - name: ssm4
+    type: SecureString
+    value: !cmd value
 secrets:
-- name: secret1
-- name: secret2
-  value: !cmd 'value'
+  - name: secret1
+  - name: secret2
+    value: !cmd value
 secrets_file: ./config.secrets.yaml
 """)
-        with open(secrets_file, 'w') as secrets:
-            secrets.write("""parameters:
-- name: ssm1
-  value: SecretData
+        with open(secrets_file, "w") as secrets:
+            secrets.write("""\
+parameters:
+  - name: ssm1
+    value: SecretData
 secrets:
-- name: secret1
-  value: SecretData
+  - name: secret1
+    value: SecretData
 """)
 
-        result = mock_cli_runner.invoke(cli, [
-            '--loglevel', "DEBUG",
-            'set-secret',
-            '--env-file', config_file,
-            '--name', 'secret3',
-            '--description', 'Secret 3'
-        ])
+        result = mock_cli_runner.invoke(
+            cli,
+            [
+                "--loglevel",
+                "DEBUG",
+                "set-secret",
+                "--env-file",
+                config_file,
+                "--name",
+                "secret3",
+            ],
+        )
 
         assert result.exit_code == 0
 
-        with open(config_file, 'r') as config:
-            assert config.read() == f"""kms:
+        with open(config_file, "r") as config:
+            assert (
+                config.read()
+                == f"""kms:
   arn: {KEY_ARN}
 parameters:
-- name: ssm1
-  type: SecureString
-- name: ssm2
-  type: String
-  value: PlainText2
-- name: ssm3
-  type: String
-  value: !cmd 'value'
-- name: ssm4
-  type: SecureString
-  value: !cmd 'value'
+  - name: ssm1
+    type: SecureString
+  - name: ssm2
+    type: String
+    value: PlainText2
+  - name: ssm3
+    type: String
+    value: !cmd value
+  - name: ssm4
+    type: SecureString
+    value: !cmd value
 secrets:
-- name: secret1
-- name: secret2
-  value: !cmd 'value'
-- description: Secret 3
-  name: secret3
+  - name: secret1
+  - name: secret2
+    value: !cmd value
+  - name: secret3
+    description: Desc
 secrets_file: ./config.secrets.yaml
 """
+            )
 
-        with open(secrets_file, 'r') as secrets:
-            assert secrets.read() == """parameters:
-- name: ssm1
-  value: SecretData
+        with open(secrets_file, "r") as secrets:
+            assert (
+                secrets.read()
+                == """\
 secrets:
-- name: secret1
-  value: SecretData
-- name: secret3
-  value: SecretData
+  - name: secret1
+    value: SecretData
+  - name: secret3
+    value: SecretData
+parameters:
+  - name: ssm1
+    value: SecretData
 """
-        mock_encrypt.assert_called_once_with(ANY, input_value, KEY_ARN)
+            )
+        mock_encrypt.assert_called_once_with(ANY, "PlainText", KEY_ARN)
 
 
-@patch('aws_secrets.miscellaneous.kms.encrypt')
-def test_set_secret_cli_with_custom_kms(
-    mock_encrypt,
-    mock_cli_runner,
-    monkeypatch
-):
+@patch("aws_secrets.miscellaneous.kms.encrypt")
+@patch("aws_secrets.cli.set_secret.prompt")
+def test_set_secret_cli_with_description(mock_prompt, mock_encrypt, mock_cli_runner):
     """
-        Should add a new secret with `--kms`
+    Should add a new secret with `--description`
     """
-    global input_captured
-    input_captured = False
-    monkeypatch.setattr('builtins.input', _mock_input)
+    mock_prompt.side_effect = ["PlainText"]
 
-    mock_encrypt.return_value = b'SecretData'
-    config_file = 'config.yaml'
-    secrets_file = 'config.secrets.yaml'
+    mock_encrypt.return_value = b"SecretData"
+    config_file = "config.yaml"
+    secrets_file = "config.secrets.yaml"
 
     with mock_cli_runner.isolated_filesystem():
-        with open(config_file, 'w') as config:
-            config.write(f"""kms:
+        with open(config_file, "w") as config:
+            config.write(f"""\
+kms:
   arn: {KEY_ARN}
 parameters:
-- name: ssm1
-  type: SecureString
-- name: ssm2
-  type: String
-  value: PlainText2
-- name: ssm3
-  type: String
-  value: !cmd 'value'
-- name: ssm4
-  type: SecureString
-  value: !cmd 'value'
+  - name: ssm1
+    type: SecureString
+  - name: ssm2
+    type: String
+    value: PlainText2
+  - name: ssm3
+    type: String
+    value: !cmd value
+  - name: ssm4
+    type: SecureString
+    value: !cmd value
 secrets:
-- name: secret1
-- name: secret2
-  value: !cmd 'value'
+  - name: secret1
+  - name: secret2
+    value: !cmd value
 secrets_file: ./config.secrets.yaml
 """)
-        with open(secrets_file, 'w') as secrets:
-            secrets.write("""parameters:
-- name: ssm1
-  value: SecretData
+        with open(secrets_file, "w") as secrets:
+            secrets.write("""\
+parameters:
+  - name: ssm1
+    value: SecretData
 secrets:
-- name: secret1
-  value: SecretData
+  - name: secret1
+    value: SecretData
 """)
 
-        result = mock_cli_runner.invoke(cli, [
-            '--loglevel', "DEBUG",
-            'set-secret',
-            '--env-file', config_file,
-            '--name', 'secret3',
-            '--kms', KEY_ARN1
-        ])
+        result = mock_cli_runner.invoke(
+            cli,
+            [
+                "--loglevel",
+                "DEBUG",
+                "set-secret",
+                "--env-file",
+                config_file,
+                "--name",
+                "secret3",
+                "--description",
+                "Secret 3",
+            ],
+        )
 
         assert result.exit_code == 0
 
-        with open(config_file, 'r') as config:
-            assert config.read() == f"""kms:
+        with open(config_file, "r") as config:
+            assert (
+                config.read()
+                == f"""\
+kms:
   arn: {KEY_ARN}
 parameters:
-- name: ssm1
-  type: SecureString
-- name: ssm2
-  type: String
-  value: PlainText2
-- name: ssm3
-  type: String
-  value: !cmd 'value'
-- name: ssm4
-  type: SecureString
-  value: !cmd 'value'
+  - name: ssm1
+    type: SecureString
+  - name: ssm2
+    type: String
+    value: PlainText2
+  - name: ssm3
+    type: String
+    value: !cmd value
+  - name: ssm4
+    type: SecureString
+    value: !cmd value
 secrets:
-- name: secret1
-- name: secret2
-  value: !cmd 'value'
-- kms: {KEY_ARN1}
-  name: secret3
+  - name: secret1
+  - name: secret2
+    value: !cmd value
+  - name: secret3
+    description: Secret 3
 secrets_file: ./config.secrets.yaml
 """
+            )
 
-        with open(secrets_file, 'r') as secrets:
-            assert secrets.read() == """parameters:
-- name: ssm1
-  value: SecretData
+        with open(secrets_file, "r") as secrets:
+            assert (
+                secrets.read()
+                == """\
 secrets:
-- name: secret1
-  value: SecretData
-- name: secret3
-  value: SecretData
+  - name: secret1
+    value: SecretData
+  - name: secret3
+    value: SecretData
+parameters:
+  - name: ssm1
+    value: SecretData
 """
-        mock_encrypt.assert_called_once_with(ANY, input_value, KEY_ARN)
+            )
+        mock_encrypt.assert_called_once_with(ANY, "PlainText", KEY_ARN)
 
 
-@patch('aws_secrets.miscellaneous.kms.encrypt')
+@patch("aws_secrets.miscellaneous.kms.encrypt")
+@patch("aws_secrets.cli.set_secret.prompt")
+def test_set_secret_cli_with_custom_kms(mock_prompt, mock_encrypt, mock_cli_runner):
+    """
+    Should add a new secret with `--kms`
+    """
+    mock_prompt.side_effect = ["Desc", "PlainText"]
+
+    mock_encrypt.return_value = b"SecretData"
+    config_file = "config.yaml"
+    secrets_file = "config.secrets.yaml"
+
+    with mock_cli_runner.isolated_filesystem():
+        with open(config_file, "w") as config:
+            config.write(f"""\
+kms:
+  arn: {KEY_ARN}
+parameters:
+  - name: ssm1
+    type: SecureString
+  - name: ssm2
+    type: String
+    value: PlainText2
+  - name: ssm3
+    type: String
+    value: !cmd value
+  - name: ssm4
+    type: SecureString
+    value: !cmd value
+secrets:
+  - name: secret1
+  - name: secret2
+    value: !cmd value
+secrets_file: ./config.secrets.yaml
+""")
+        with open(secrets_file, "w") as secrets:
+            secrets.write("""\
+parameters:
+  - name: ssm1
+    value: SecretData
+secrets:
+  - name: secret1
+    value: SecretData
+""")
+
+        result = mock_cli_runner.invoke(
+            cli,
+            [
+                "--loglevel",
+                "DEBUG",
+                "set-secret",
+                "--env-file",
+                config_file,
+                "--name",
+                "secret3",
+                "--kms",
+                KEY_ARN1,
+            ],
+        )
+
+        assert result.exit_code == 0
+
+        with open(config_file, "r") as config:
+            assert (
+                config.read()
+                == f"""\
+kms:
+  arn: {KEY_ARN}
+parameters:
+  - name: ssm1
+    type: SecureString
+  - name: ssm2
+    type: String
+    value: PlainText2
+  - name: ssm3
+    type: String
+    value: !cmd value
+  - name: ssm4
+    type: SecureString
+    value: !cmd value
+secrets:
+  - name: secret1
+  - name: secret2
+    value: !cmd value
+  - name: secret3
+    description: Desc
+    kms: {KEY_ARN1}
+secrets_file: ./config.secrets.yaml
+"""
+            )
+
+        with open(secrets_file, "r") as secrets:
+            assert (
+                secrets.read()
+                == """\
+secrets:
+  - name: secret1
+    value: SecretData
+  - name: secret3
+    value: SecretData
+parameters:
+  - name: ssm1
+    value: SecretData
+"""
+            )
+        mock_encrypt.assert_called_once_with(ANY, "PlainText", KEY_ARN)
+
+
+@patch("aws_secrets.miscellaneous.kms.encrypt")
+@patch("aws_secrets.miscellaneous.kms.decrypt")
+@patch("aws_secrets.cli.set_secret.prompt")
 def test_set_secret_cli_update_exists_secret(
-    mock_encrypt,
-    mock_cli_runner,
-    monkeypatch
+    mock_prompt, mock_decrypt, mock_encrypt, mock_cli_runner
 ):
     """
-        Should update an existing secret
+    Should update an existing secret
     """
-    global input_captured
-    input_captured = False
-    monkeypatch.setattr('builtins.input', _mock_input)
+    mock_prompt.side_effect = ["Desc1", "PlainText"]
 
-    mock_encrypt.return_value = b'ChangedData'
-    config_file = 'config.yaml'
-    secrets_file = 'config.secrets.yaml'
+    mock_encrypt.return_value = b"ChangedData"
+    mock_decrypt.return_value = b"SecretData"
+    config_file = "config.yaml"
+    secrets_file = "config.secrets.yaml"
 
     with mock_cli_runner.isolated_filesystem():
-        with open(config_file, 'w') as config:
-            config.write(f"""kms:
+        with open(config_file, "w") as config:
+            config.write(f"""\
+kms:
   arn: {KEY_ARN}
 parameters:
-- name: ssm1
-  type: SecureString
-- name: ssm2
-  type: String
-  value: PlainText2
-- name: ssm3
-  type: String
-  value: !cmd 'value'
-- name: ssm4
-  type: SecureString
-  value: !cmd 'value'
+  - name: ssm1
+    type: SecureString
+  - name: ssm2
+    type: String
+    value: PlainText2
+  - name: ssm3
+    type: String
+    value: !cmd value
+  - name: ssm4
+    type: SecureString
+    value: !cmd value
 secrets:
-- name: secret1
-- name: secret2
-  value: !cmd 'value'
+  - name: secret1
+    description: Desc
+  - name: secret2
+    value: !cmd value
 secrets_file: ./config.secrets.yaml
 """)
-        with open(secrets_file, 'w') as secrets:
-            secrets.write("""parameters:
-- name: ssm1
-  value: SecretData
+        with open(secrets_file, "w") as secrets:
+            secrets.write("""\
+parameters:
+  - name: ssm1
+    value: SecretData
 secrets:
-- name: secret1
-  value: SecretData
+  - name: secret1
+    value: SecretData
 """)
 
-        result = mock_cli_runner.invoke(cli, [
-            '--loglevel', "DEBUG",
-            'set-secret',
-            '--env-file', config_file,
-            '--name', 'secret1'
-        ])
+        result = mock_cli_runner.invoke(
+            cli,
+            [
+                "--loglevel",
+                "DEBUG",
+                "set-secret",
+                "--env-file",
+                config_file,
+                "--name",
+                "secret1",
+            ],
+        )
 
         assert result.exit_code == 0
 
-        with open(config_file, 'r') as config:
-            assert config.read() == f"""kms:
+        with open(config_file, "r") as config:
+            assert (
+                config.read()
+                == f"""\
+kms:
   arn: {KEY_ARN}
 parameters:
-- name: ssm1
-  type: SecureString
-- name: ssm2
-  type: String
-  value: PlainText2
-- name: ssm3
-  type: String
-  value: !cmd 'value'
-- name: ssm4
-  type: SecureString
-  value: !cmd 'value'
+  - name: ssm1
+    type: SecureString
+  - name: ssm2
+    type: String
+    value: PlainText2
+  - name: ssm3
+    type: String
+    value: !cmd value
+  - name: ssm4
+    type: SecureString
+    value: !cmd value
 secrets:
-- name: secret1
-- name: secret2
-  value: !cmd 'value'
+  - name: secret1
+    description: Desc1
+  - name: secret2
+    value: !cmd value
 secrets_file: ./config.secrets.yaml
 """
+            )
 
-        with open(secrets_file, 'r') as secrets:
-            assert secrets.read() == """parameters:
-- name: ssm1
-  value: SecretData
+        with open(secrets_file, "r") as secrets:
+            assert (
+                secrets.read()
+                == """\
 secrets:
-- name: secret1
-  value: ChangedData
+  - name: secret1
+    value: ChangedData
+parameters:
+  - name: ssm1
+    value: SecretData
 """
-        mock_encrypt.assert_called_once_with(ANY, input_value, KEY_ARN)
+            )
+        mock_encrypt.assert_called_once_with(ANY, "PlainText", KEY_ARN)

--- a/tests/config/providers/secretsmanager/test_entry.py
+++ b/tests/config/providers/secretsmanager/test_entry.py
@@ -4,445 +4,445 @@ from unittest.mock import MagicMock, patch
 import boto3
 from botocore.stub import Stubber
 
-from aws_secrets.config.providers.secretsmanager.entry import SecretManagerEntry
+from aws_secrets.config.providers.secretsmanager.entry import \
+    SecretManagerEntry
 from aws_secrets.tags.cmd import CmdTag
 
-KEY_ARN = 'arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab'
-KEY_ARN1 = 'arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab1'
+KEY_ARN = "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
+KEY_ARN1 = (
+    "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab1"
+)
 
-SECRET_ARN = 'arn:aws:secretsmanager:us-west-2:111122223333:secret:aes256-7g8H9i'
+SECRET_ARN = "arn:aws:secretsmanager:us-west-2:111122223333:secret:aes256-7g8H9i"
 
 
-@patch('aws_secrets.miscellaneous.kms.encrypt')
+@patch("aws_secrets.miscellaneous.kms.encrypt")
 def test_encrypt(mock_encrypt):
     """
-        Should encrypt the raw value
+    Should encrypt the raw value
     """
 
-    mock_encrypt.return_value = b'SecretData'
+    mock_encrypt.return_value = b"SecretData"
 
-    session = boto3.Session(region_name='us-east-1')
+    session = boto3.Session(region_name="us-east-1")
     provider_mock = MagicMock()
-    provider_mock.encryption_sdk = 'boto3'
+    provider_mock.encryption_sdk = "boto3"
 
     entry = SecretManagerEntry(
         session=session,
         kms_arn=KEY_ARN,
-        data={
-            'name': 'secret1',
-            'value': 'MyPlainText'
-        },
+        data={"name": "secret1", "value": "MyPlainText"},
         provider=provider_mock,
-        cipher_text=None
+        cipher_text=None,
     )
 
-    assert entry.encrypt() == 'SecretData'
-    mock_encrypt.assert_called_once_with(session, 'MyPlainText', KEY_ARN)
+    assert entry.encrypt() == "SecretData"
+    mock_encrypt.assert_called_once_with(session, "MyPlainText", KEY_ARN)
 
 
-@patch('aws_secrets.miscellaneous.kms.encrypt')
+@patch("aws_secrets.miscellaneous.kms.encrypt")
 def test_encrypt_value_dict(mock_encrypt):
     """
-        Should encrypt the raw value
+    Should encrypt the raw value
     """
 
-    mock_encrypt.return_value = b'SecretData'
+    mock_encrypt.return_value = b"SecretData"
 
-    session = boto3.Session(region_name='us-east-1')
+    session = boto3.Session(region_name="us-east-1")
     provider_mock = MagicMock()
-    provider_mock.encryption_sdk = 'boto3'
+    provider_mock.encryption_sdk = "boto3"
 
-    value = {
-        'key': 'MyPlainText'
-    }
+    value = {"key": "MyPlainText"}
 
     entry = SecretManagerEntry(
         session=session,
         kms_arn=KEY_ARN,
-        data={
-            'name': 'secret1',
-            'value': value
-        },
+        data={"name": "secret1", "value": value},
         provider=provider_mock,
-        cipher_text=None
+        cipher_text=None,
     )
 
-    assert entry.encrypt() == 'SecretData'
+    assert entry.encrypt() == "SecretData"
     mock_encrypt.assert_called_once_with(session, json.dumps(value), KEY_ARN)
 
 
-@patch('aws_secrets.miscellaneous.kms.encrypt')
+@patch("aws_secrets.miscellaneous.kms.encrypt")
 def test_encrypt_already_encrypted(mock_encrypt):
     """
-        Should not encrypt the raw value when the value is already encrypted
+    Should not encrypt the raw value when the value is already encrypted
     """
 
-    session = boto3.Session(region_name='us-east-1')
+    session = boto3.Session(region_name="us-east-1")
     provider_mock = MagicMock()
-    provider_mock.encryption_sdk = 'boto3'
+    provider_mock.encryption_sdk = "boto3"
 
     entry = SecretManagerEntry(
         session=session,
         kms_arn=KEY_ARN,
-        data={
-            'name': 'secret1'
-        },
+        data={"name": "secret1"},
         provider=provider_mock,
-        cipher_text='SecretData'
+        cipher_text="SecretData",
     )
 
-    assert entry.encrypt() == 'SecretData'
+    assert entry.encrypt() == "SecretData"
     mock_encrypt.assert_not_called()
 
 
-@patch('aws_secrets.miscellaneous.kms.decrypt')
+@patch("aws_secrets.miscellaneous.kms.decrypt")
 def test_decrypt(mock_decrypt):
     """
-        Should decrypt the cipher text
+    Should decrypt the cipher text
     """
 
-    mock_decrypt.return_value = b'PlainTextData'
+    mock_decrypt.return_value = b"PlainTextData"
 
-    session = boto3.Session(region_name='us-east-1')
+    session = boto3.Session(region_name="us-east-1")
     provider_mock = MagicMock()
-    provider_mock.encryption_sdk = 'boto3'
+    provider_mock.encryption_sdk = "boto3"
 
     entry = SecretManagerEntry(
         session=session,
         kms_arn=KEY_ARN,
-        data={
-            'name': 'secret1'
-        },
+        data={"name": "secret1"},
         provider=provider_mock,
-        cipher_text='SecretData'
+        cipher_text="SecretData",
     )
 
-    assert entry.decrypt() == 'PlainTextData'
-    mock_decrypt.assert_called_once_with(session, 'SecretData', KEY_ARN)
+    assert entry.decrypt() == "PlainTextData"
+    mock_decrypt.assert_called_once_with(session, "SecretData", KEY_ARN)
 
 
-@patch('aws_secrets.miscellaneous.kms.decrypt')
+@patch("aws_secrets.miscellaneous.kms.decrypt")
+def test_decrypt_format(mock_decrypt):
+    """
+    Should decrypt the cipher text
+    """
+
+    mock_decrypt.return_value = b"{\"key\": \"PlainTextData\"}"
+
+    session = boto3.Session(region_name="us-east-1")
+    provider_mock = MagicMock()
+    provider_mock.encryption_sdk = "boto3"
+
+    entry = SecretManagerEntry(
+        session=session,
+        kms_arn=KEY_ARN,
+        data={"name": "secret1"},
+        provider=provider_mock,
+        cipher_text="SecretData",
+    )
+
+    assert entry.decrypt(format=True) == "{\n  \"key\": \"PlainTextData\"\n}"
+    mock_decrypt.assert_called_once_with(session, "SecretData", KEY_ARN)
+
+
+@patch("aws_secrets.miscellaneous.kms.decrypt")
 def test_decrypt_with_value_data(mock_decrypt):
     """
-        Should decrypt the cipher text
+    Should decrypt the cipher text
     """
 
-    mock_decrypt.return_value = b'PlainTextData'
+    mock_decrypt.return_value = b"PlainTextData"
 
-    session = boto3.Session(region_name='us-east-1')
+    session = boto3.Session(region_name="us-east-1")
     provider_mock = MagicMock()
-    provider_mock.encryption_sdk = 'boto3'
+    provider_mock.encryption_sdk = "boto3"
 
     entry = SecretManagerEntry(
         session=session,
         kms_arn=KEY_ARN,
-        data={
-            'name': 'secret1',
-            'value': 'SecretData'
-        },
+        data={"name": "secret1", "value": "SecretData"},
         provider=provider_mock,
-        cipher_text=None
+        cipher_text=None,
     )
 
-    assert entry.decrypt() == 'PlainTextData'
-    mock_decrypt.assert_called_once_with(session, 'SecretData', KEY_ARN)
+    assert entry.decrypt() == "PlainTextData"
+    mock_decrypt.assert_called_once_with(session, "SecretData", KEY_ARN)
 
 
-@patch('subprocess.run')
+@patch("subprocess.run")
 def test_decrypt_with_value_data_not_str(mock_run):
     """
-        Should decrypt the cipher text
+    Should decrypt the cipher text
     """
 
-    session = boto3.Session(region_name='us-east-1')
-    mock_run.return_value.stdout = 'myvalue'
+    session = boto3.Session(region_name="us-east-1")
+    mock_run.return_value.stdout = "myvalue"
     provider_mock = MagicMock()
-    provider_mock.encryption_sdk = 'boto3'
+    provider_mock.encryption_sdk = "boto3"
 
     entry = SecretManagerEntry(
         session=session,
         kms_arn=KEY_ARN,
-        data={
-            'name': 'secret1',
-            'value': CmdTag('value')
-        },
+        data={"name": "secret1", "value": CmdTag("value")},
         provider=provider_mock,
-        cipher_text=None
+        cipher_text=None,
     )
 
     assert isinstance(entry.decrypt(), CmdTag)
 
 
-@patch('aws_secrets.miscellaneous.kms.decrypt')
+@patch("aws_secrets.miscellaneous.kms.decrypt")
 def test_create_default_kms(mock_decrypt):
     """
-        Should create the secret in the AWS environment
+    Should create the secret in the AWS environment
     """
-    client = boto3.client('secretsmanager')
-    mock_decrypt.return_value = b'PlainTextData'
+    client = boto3.client("secretsmanager")
+    mock_decrypt.return_value = b"PlainTextData"
 
-    with patch.object(boto3.Session, 'client') as mock_client:
+    with patch.object(boto3.Session, "client") as mock_client:
         with Stubber(client) as stubber:
-            name = 'secret1'
-            description = 'secret description'
+            name = "secret1"
+            description = "secret description"
 
             mock_client.return_value = client
-            stubber.add_response('create_secret', {}, {
-                'Name': name,
-                'Description': description,
-                'SecretString': 'PlainTextData',
-                'Tags': []
-            })
+            stubber.add_response(
+                "create_secret",
+                {},
+                {
+                    "Name": name,
+                    "Description": description,
+                    "SecretString": "PlainTextData",
+                    "Tags": [],
+                },
+            )
 
-            session = boto3.Session(region_name='us-east-1')
+            session = boto3.Session(region_name="us-east-1")
             provider_mock = MagicMock()
-            provider_mock.encryption_sdk = 'boto3'
+            provider_mock.encryption_sdk = "boto3"
 
             entry = SecretManagerEntry(
                 session=session,
-                cipher_text='SecretData',
+                cipher_text="SecretData",
                 kms_arn=KEY_ARN,
-                data={
-                    'name': name,
-                    'description': description
-                },
-                provider=provider_mock
+                data={"name": name, "description": description},
+                provider=provider_mock,
             )
 
             entry.create()
             assert True
-            mock_decrypt.assert_called_once_with(session, 'SecretData', KEY_ARN)
+            mock_decrypt.assert_called_once_with(session, "SecretData", KEY_ARN)
 
 
-@patch('aws_secrets.miscellaneous.kms.decrypt')
+@patch("aws_secrets.miscellaneous.kms.decrypt")
 def test_create_custom_kms(mock_decrypt):
     """
-        Should create the secret in the AWS environment using a custom Kms key
+    Should create the secret in the AWS environment using a custom Kms key
     """
-    client = boto3.client('secretsmanager')
-    mock_decrypt.return_value = b'PlainTextData'
+    client = boto3.client("secretsmanager")
+    mock_decrypt.return_value = b"PlainTextData"
 
-    with patch.object(boto3.Session, 'client') as mock_client:
+    with patch.object(boto3.Session, "client") as mock_client:
         with Stubber(client) as stubber:
-            name = 'secret1'
-            description = 'secret description'
+            name = "secret1"
+            description = "secret description"
 
             mock_client.return_value = client
-            stubber.add_response('create_secret', {}, {
-                'Name': name,
-                'Description': description,
-                'SecretString': 'PlainTextData',
-                'KmsKeyId': KEY_ARN,
-                'Tags': []
-            })
+            stubber.add_response(
+                "create_secret",
+                {},
+                {
+                    "Name": name,
+                    "Description": description,
+                    "SecretString": "PlainTextData",
+                    "KmsKeyId": KEY_ARN,
+                    "Tags": [],
+                },
+            )
 
-            session = boto3.Session(region_name='us-east-1')
+            session = boto3.Session(region_name="us-east-1")
             provider_mock = MagicMock()
-            provider_mock.encryption_sdk = 'boto3'
+            provider_mock.encryption_sdk = "boto3"
 
             entry = SecretManagerEntry(
                 session=session,
-                cipher_text='SecretData',
+                cipher_text="SecretData",
                 kms_arn=KEY_ARN,
-                data={
-                    'name': name,
-                    'description': description,
-                    'kms': KEY_ARN
-                },
-                provider=provider_mock
+                data={"name": name, "description": description, "kms": KEY_ARN},
+                provider=provider_mock,
             )
 
             entry.create()
             assert True
-            mock_decrypt.assert_called_once_with(session, 'SecretData', KEY_ARN)
+            mock_decrypt.assert_called_once_with(session, "SecretData", KEY_ARN)
 
 
-@patch('aws_secrets.miscellaneous.kms.decrypt')
+@patch("aws_secrets.miscellaneous.kms.decrypt")
 def test_update_default_kms_without_tag_changes(mock_decrypt):
     """
-        Should update the secret in the AWS environment without tag changes
+    Should update the secret in the AWS environment without tag changes
     """
-    client = boto3.client('secretsmanager')
-    mock_decrypt.return_value = b'PlainTextData'
+    client = boto3.client("secretsmanager")
+    mock_decrypt.return_value = b"PlainTextData"
 
-    with patch.object(boto3.Session, 'client') as mock_client:
+    with patch.object(boto3.Session, "client") as mock_client:
         with Stubber(client) as stubber:
-            name = 'secret1'
-            description = 'secret description'
+            name = "secret1"
+            description = "secret description"
 
             mock_client.return_value = client
-            stubber.add_response('update_secret', {}, {
-                'SecretId': name,
-                'Description': description,
-                'SecretString': 'PlainTextData'
-            })
-            stubber.add_response('untag_resource', {}, {
-                'SecretId': name,
-                'TagKeys': []
-            })
+            stubber.add_response(
+                "update_secret",
+                {},
+                {
+                    "SecretId": name,
+                    "Description": description,
+                    "SecretString": "PlainTextData",
+                },
+            )
+            stubber.add_response(
+                "untag_resource", {}, {"SecretId": name, "TagKeys": []}
+            )
 
-            session = boto3.Session(region_name='us-east-1')
+            session = boto3.Session(region_name="us-east-1")
             provider_mock = MagicMock()
-            provider_mock.encryption_sdk = 'boto3'
+            provider_mock.encryption_sdk = "boto3"
 
             entry = SecretManagerEntry(
                 session=session,
-                cipher_text='SecretData',
+                cipher_text="SecretData",
                 kms_arn=KEY_ARN,
-                data={
-                    'name': name,
-                    'description': description
-                },
-                provider=provider_mock
+                data={"name": name, "description": description},
+                provider=provider_mock,
             )
 
-            entry.update({
-                'ChangesList': []
-            })
+            entry.update({"ChangesList": []})
             assert True
-            mock_decrypt.assert_called_once_with(session, 'SecretData', KEY_ARN)
+            mock_decrypt.assert_called_once_with(session, "SecretData", KEY_ARN)
 
 
-@patch('aws_secrets.miscellaneous.kms.decrypt')
+@patch("aws_secrets.miscellaneous.kms.decrypt")
 def test_update_custom_kms_without_tag_changes(mock_decrypt):
     """
-        Should update the secret in the AWS environment without tag changes
+    Should update the secret in the AWS environment without tag changes
     """
-    client = boto3.client('secretsmanager')
-    mock_decrypt.return_value = b'PlainTextData'
+    client = boto3.client("secretsmanager")
+    mock_decrypt.return_value = b"PlainTextData"
 
-    with patch.object(boto3.Session, 'client') as mock_client:
+    with patch.object(boto3.Session, "client") as mock_client:
         with Stubber(client) as stubber:
-            name = 'secret1'
-            description = 'secret description'
+            name = "secret1"
+            description = "secret description"
 
             mock_client.return_value = client
-            stubber.add_response('update_secret', {}, {
-                'SecretId': name,
-                'Description': description,
-                'SecretString': 'PlainTextData',
-                'KmsKeyId': KEY_ARN
-            })
-            stubber.add_response('untag_resource', {}, {
-                'SecretId': name,
-                'TagKeys': []
-            })
+            stubber.add_response(
+                "update_secret",
+                {},
+                {
+                    "SecretId": name,
+                    "Description": description,
+                    "SecretString": "PlainTextData",
+                    "KmsKeyId": KEY_ARN,
+                },
+            )
+            stubber.add_response(
+                "untag_resource", {}, {"SecretId": name, "TagKeys": []}
+            )
 
-            session = boto3.Session(region_name='us-east-1')
+            session = boto3.Session(region_name="us-east-1")
             provider_mock = MagicMock()
-            provider_mock.encryption_sdk = 'boto3'
+            provider_mock.encryption_sdk = "boto3"
 
             entry = SecretManagerEntry(
                 session=session,
-                cipher_text='SecretData',
+                cipher_text="SecretData",
                 kms_arn=KEY_ARN,
-                data={
-                    'name': name,
-                    'description': description,
-                    'kms': KEY_ARN
-                },
-                provider=provider_mock
+                data={"name": name, "description": description, "kms": KEY_ARN},
+                provider=provider_mock,
             )
 
-            entry.update({
-                'ChangesList': []
-            })
+            entry.update({"ChangesList": []})
             assert True
-            mock_decrypt.assert_called_once_with(session, 'SecretData', KEY_ARN)
+            mock_decrypt.assert_called_once_with(session, "SecretData", KEY_ARN)
 
 
-@patch('aws_secrets.miscellaneous.kms.decrypt')
+@patch("aws_secrets.miscellaneous.kms.decrypt")
 def test_update_default_kms_with_tag_changes(mock_decrypt):
     """
-        Should update the secret in the AWS environment with tag changes
+    Should update the secret in the AWS environment with tag changes
     """
-    client = boto3.client('secretsmanager')
-    mock_decrypt.return_value = b'PlainTextData'
+    client = boto3.client("secretsmanager")
+    mock_decrypt.return_value = b"PlainTextData"
 
-    with patch.object(boto3.Session, 'client') as mock_client:
+    with patch.object(boto3.Session, "client") as mock_client:
         with Stubber(client) as stubber:
-            name = 'secret1'
-            description = 'secret description'
+            name = "secret1"
+            description = "secret description"
 
             mock_client.return_value = client
-            stubber.add_response('update_secret', {}, {
-                'SecretId': name,
-                'Description': description,
-                'SecretString': 'PlainTextData'
-            })
-            stubber.add_response('untag_resource', {}, {
-                'SecretId': name,
-                'TagKeys': ['Test']
-            })
-            stubber.add_response('tag_resource', {}, {
-                'SecretId': name,
-                'Tags': [{
-                    'Key': 'Test',
-                    'Value': 'New'
-                }]
-            })
+            stubber.add_response(
+                "update_secret",
+                {},
+                {
+                    "SecretId": name,
+                    "Description": description,
+                    "SecretString": "PlainTextData",
+                },
+            )
+            stubber.add_response(
+                "untag_resource", {}, {"SecretId": name, "TagKeys": ["Test"]}
+            )
+            stubber.add_response(
+                "tag_resource",
+                {},
+                {"SecretId": name, "Tags": [{"Key": "Test", "Value": "New"}]},
+            )
 
-            session = boto3.Session(region_name='us-east-1')
+            session = boto3.Session(region_name="us-east-1")
             provider_mock = MagicMock()
-            provider_mock.encryption_sdk = 'boto3'
+            provider_mock.encryption_sdk = "boto3"
 
             entry = SecretManagerEntry(
                 session=session,
-                cipher_text='SecretData',
+                cipher_text="SecretData",
                 kms_arn=KEY_ARN,
                 data={
-                    'name': name,
-                    'description': description,
-                    'tags': {
-                        'Test': 'New'
-                    }
+                    "name": name,
+                    "description": description,
+                    "tags": {"Test": "New"},
                 },
-                provider=provider_mock
+                provider=provider_mock,
             )
 
-            entry.update({
-                'ChangesList': [{
-                    'Key': 'Tags',
-                    'OldValue': [{
-                        'Key': 'Test',
-                        'Value': 'Old'
-                    }]
-                }]
-            })
+            entry.update(
+                {
+                    "ChangesList": [
+                        {"Key": "Tags", "OldValue": [{"Key": "Test", "Value": "Old"}]}
+                    ]
+                }
+            )
             assert True
-            mock_decrypt.assert_called_once_with(session, 'SecretData', KEY_ARN)
+            mock_decrypt.assert_called_once_with(session, "SecretData", KEY_ARN)
 
 
 def test_delete():
     """
-        Should delete the secret in the AWS environment
+    Should delete the secret in the AWS environment
     """
-    client = boto3.client('secretsmanager')
+    client = boto3.client("secretsmanager")
 
-    with patch.object(boto3.Session, 'client') as mock_client:
+    with patch.object(boto3.Session, "client") as mock_client:
         with Stubber(client) as stubber:
-            name = 'secret1'
-            description = 'secret description'
+            name = "secret1"
+            description = "secret description"
 
             mock_client.return_value = client
-            stubber.add_response('delete_secret', {}, {
-                'SecretId': name,
-                'ForceDeleteWithoutRecovery': True
-            })
+            stubber.add_response(
+                "delete_secret",
+                {},
+                {"SecretId": name, "ForceDeleteWithoutRecovery": True},
+            )
 
-            session = boto3.Session(region_name='us-east-1')
+            session = boto3.Session(region_name="us-east-1")
             provider_mock = MagicMock()
-            provider_mock.encryption_sdk = 'boto3'
+            provider_mock.encryption_sdk = "boto3"
 
             entry = SecretManagerEntry(
                 session=session,
-                cipher_text='SecretData',
+                cipher_text="SecretData",
                 kms_arn=KEY_ARN,
-                data={
-                    'name': name,
-                    'description': description
-                },
-                provider=provider_mock
+                data={"name": name, "description": description},
+                provider=provider_mock,
             )
 
             entry.delete()
@@ -451,265 +451,240 @@ def test_delete():
 
 def test_calculate_changes_with_parameter_not_exists():
     """
-        Should calculate the changes between AWS resource and local resource
+    Should calculate the changes between AWS resource and local resource
 
-        Scenario:
-            - secret not exists
+    Scenario:
+        - secret not exists
     """
-    client = boto3.client('secretsmanager')
+    client = boto3.client("secretsmanager")
 
-    with patch.object(boto3.Session, 'client') as mock_client:
+    with patch.object(boto3.Session, "client") as mock_client:
         with Stubber(client) as stubber:
-            name = 'secret1'
-            description = 'secret description'
+            name = "secret1"
+            description = "secret description"
 
             mock_client.return_value = client
-            stubber.add_response('list_secrets', {
-                'SecretList': []
-            }, {
-                'Filters': [
-                    {
-                        'Key': 'name',
-                        'Values': [name]
-                    }
-                ]
-            })
+            stubber.add_response(
+                "list_secrets",
+                {"SecretList": []},
+                {"Filters": [{"Key": "name", "Values": [name]}]},
+            )
 
-            session = boto3.Session(region_name='us-east-1')
+            session = boto3.Session(region_name="us-east-1")
             provider_mock = MagicMock()
-            provider_mock.encryption_sdk = 'boto3'
+            provider_mock.encryption_sdk = "boto3"
 
             entry = SecretManagerEntry(
                 session=session,
-                cipher_text='SecretData',
+                cipher_text="SecretData",
                 kms_arn=KEY_ARN,
                 data={
-                    'name': name,
-                    'description': description,
+                    "name": name,
+                    "description": description,
                 },
-                provider=provider_mock
+                provider=provider_mock,
             )
 
-            assert entry.changes() == {
-                'Exists': False,
-                'ChangesList': []
-            }
+            assert entry.changes() == {"Exists": False, "ChangesList": []}
 
 
-@patch('aws_secrets.miscellaneous.kms.decrypt')
+@patch("aws_secrets.miscellaneous.kms.decrypt")
 def test_calculate_changes_with_changes(mock_decrypt):
     """
-        Should calculate the changes between AWS resource and local resource
+    Should calculate the changes between AWS resource and local resource
 
-        Scenario:
-            - Parameter exists
-            - Value changed
-            - Description changed
-            - Kms changed
-            - Tags changed
+    Scenario:
+        - Parameter exists
+        - Value changed
+        - Description changed
+        - Kms changed
+        - Tags changed
     """
-    client = boto3.client('secretsmanager')
-    mock_decrypt.return_value = b'PlainTextData'
+    client = boto3.client("secretsmanager")
+    mock_decrypt.return_value = b"PlainTextData"
 
-    with patch.object(boto3.Session, 'client') as mock_client:
+    with patch.object(boto3.Session, "client") as mock_client:
         with Stubber(client) as stubber:
-            name = 'secret1'
-            description = 'secret description'
+            name = "secret1"
+            description = "secret description"
 
             mock_client.return_value = client
-            stubber.add_response('list_secrets', {
-                'SecretList': [{
-                    'ARN': SECRET_ARN,
-                    'Name': name,
-                    'Description': f'{description} CHANGED',
-                    'KmsKeyId': KEY_ARN1,
-                    'Tags': [{
-                        'Key': 'Test',
-                        'Value': 'Old'
-                    }]
-                }]
-            }, {
-                'Filters': [
-                    {
-                        'Key': 'name',
-                        'Values': [name]
-                    }
-                ]
-            })
-            stubber.add_response('get_secret_value', {
-                'SecretString': 'AWSData'
-            }, {
-                'SecretId': name
-            })
+            stubber.add_response(
+                "list_secrets",
+                {
+                    "SecretList": [
+                        {
+                            "ARN": SECRET_ARN,
+                            "Name": name,
+                            "Description": f"{description} CHANGED",
+                            "KmsKeyId": KEY_ARN1,
+                            "Tags": [{"Key": "Test", "Value": "Old"}],
+                        }
+                    ]
+                },
+                {"Filters": [{"Key": "name", "Values": [name]}]},
+            )
+            stubber.add_response(
+                "get_secret_value", {"SecretString": "AWSData"}, {"SecretId": name}
+            )
 
-            session = boto3.Session(region_name='us-east-1')
+            session = boto3.Session(region_name="us-east-1")
             provider_mock = MagicMock()
-            provider_mock.encryption_sdk = 'boto3'
+            provider_mock.encryption_sdk = "boto3"
 
             entry = SecretManagerEntry(
                 session=session,
-                cipher_text='SecretData',
+                cipher_text="SecretData",
                 kms_arn=KEY_ARN,
                 data={
-                    'name': name,
-                    'description': description,
-                    'kms': KEY_ARN,
-                    'tags': {
-                        'Test': 'New'
-                    }
+                    "name": name,
+                    "description": description,
+                    "kms": KEY_ARN,
+                    "tags": {"Test": "New"},
                 },
-                provider=provider_mock
+                provider=provider_mock,
             )
 
             assert entry.changes() == {
-                'Exists': True,
-                'ChangesList': [{
-                    'HasChanges': True,
-                    'Key': 'Value',
-                    'OldValue': 'AWSData',
-                    'Replaceable': True,
-                    'Value': 'PlainTextData'
-                }, {
-                    'HasChanges': True,
-                    'Key': 'Description',
-                    'OldValue': 'secret description CHANGED',
-                    'Replaceable': True,
-                    'Value': 'secret description',
-                }, {
-                    'HasChanges': True,
-                    'Key': 'KmsKeyId',
-                    'OldValue': KEY_ARN1,
-                    'Replaceable': True,
-                    'Value': KEY_ARN
-                }, {
-                    'HasChanges': True,
-                    'Key': 'Tags',
-                    'OldValue': [{'Key': 'Test', 'Value': 'Old'}],
-                    'Replaceable': True,
-                    'Value': [{'Key': 'Test', 'Value': 'New'}],
-                }]
+                "Exists": True,
+                "ChangesList": [
+                    {
+                        "HasChanges": True,
+                        "Key": "Value",
+                        "OldValue": "AWSData",
+                        "Replaceable": True,
+                        "Value": "PlainTextData",
+                    },
+                    {
+                        "HasChanges": True,
+                        "Key": "Description",
+                        "OldValue": "secret description CHANGED",
+                        "Replaceable": True,
+                        "Value": "secret description",
+                    },
+                    {
+                        "HasChanges": True,
+                        "Key": "KmsKeyId",
+                        "OldValue": KEY_ARN1,
+                        "Replaceable": True,
+                        "Value": KEY_ARN,
+                    },
+                    {
+                        "HasChanges": True,
+                        "Key": "Tags",
+                        "OldValue": [{"Key": "Test", "Value": "Old"}],
+                        "Replaceable": True,
+                        "Value": [{"Key": "Test", "Value": "New"}],
+                    },
+                ],
             }
 
 
-@patch('aws_secrets.miscellaneous.kms.decrypt')
+@patch("aws_secrets.miscellaneous.kms.decrypt")
 def test_calculate_changes_without_changes(mock_decrypt):
     """
-        Should calculate the changes between AWS resource and local resource
+    Should calculate the changes between AWS resource and local resource
 
-        Scenario:
-            - secret exists
-            - Value not changed
-            - Description not changed
-            - Type not changed
-            - Kms not changed
-            - Tags not changed
+    Scenario:
+        - secret exists
+        - Value not changed
+        - Description not changed
+        - Type not changed
+        - Kms not changed
+        - Tags not changed
     """
-    client = boto3.client('secretsmanager')
-    mock_decrypt.return_value = b'PlainTextData'
+    client = boto3.client("secretsmanager")
+    mock_decrypt.return_value = b"PlainTextData"
 
-    with patch.object(boto3.Session, 'client') as mock_client:
+    with patch.object(boto3.Session, "client") as mock_client:
         with Stubber(client) as stubber:
-            name = 'secret1'
-            description = 'secret description'
+            name = "secret1"
+            description = "secret description"
 
             mock_client.return_value = client
-            stubber.add_response('list_secrets', {
-                'SecretList': [{
-                    'ARN': SECRET_ARN,
-                    'Name': name,
-                    'Description': description,
-                    'KmsKeyId': KEY_ARN,
-                    'Tags': [{
-                        'Key': 'Test',
-                        'Value': 'New'
-                    }]
-                }]
-            }, {
-                'Filters': [
-                    {
-                        'Key': 'name',
-                        'Values': [name]
-                    }
-                ]
-            })
-            stubber.add_response('get_secret_value', {
-                'SecretString': 'PlainTextData'
-            }, {
-                'SecretId': name
-            })
-
-            session = boto3.Session(region_name='us-east-1')
-            provider_mock = MagicMock()
-            provider_mock.encryption_sdk = 'boto3'
-            entry = SecretManagerEntry(
-                session=session,
-                cipher_text='SecretData',
-                kms_arn=KEY_ARN,
-                data={
-                    'name': name,
-                    'description': description,
-                    'kms': KEY_ARN,
-                    'tags': {
-                        'Test': 'New'
-                    }
+            stubber.add_response(
+                "list_secrets",
+                {
+                    "SecretList": [
+                        {
+                            "ARN": SECRET_ARN,
+                            "Name": name,
+                            "Description": description,
+                            "KmsKeyId": KEY_ARN,
+                            "Tags": [{"Key": "Test", "Value": "New"}],
+                        }
+                    ]
                 },
-                provider=provider_mock
+                {"Filters": [{"Key": "name", "Values": [name]}]},
+            )
+            stubber.add_response(
+                "get_secret_value",
+                {"SecretString": "PlainTextData"},
+                {"SecretId": name},
             )
 
-            assert entry.changes() == {
-                'Exists': True,
-                'ChangesList': []
-            }
+            session = boto3.Session(region_name="us-east-1")
+            provider_mock = MagicMock()
+            provider_mock.encryption_sdk = "boto3"
+            entry = SecretManagerEntry(
+                session=session,
+                cipher_text="SecretData",
+                kms_arn=KEY_ARN,
+                data={
+                    "name": name,
+                    "description": description,
+                    "kms": KEY_ARN,
+                    "tags": {"Test": "New"},
+                },
+                provider=provider_mock,
+            )
+
+            assert entry.changes() == {"Exists": True, "ChangesList": []}
 
 
-@patch('aws_secrets.miscellaneous.crypto.encrypt')
+@patch("aws_secrets.miscellaneous.crypto.encrypt")
 def test_encrypt_aws_encryption_sdk(mock_encrypt):
     """
-        Should encrypt the raw value using AWS encryption SDK
+    Should encrypt the raw value using AWS encryption SDK
     """
 
-    mock_encrypt.return_value = 'SecretData'
+    mock_encrypt.return_value = "SecretData"
 
-    session = boto3.Session(region_name='us-east-1')
+    session = boto3.Session(region_name="us-east-1")
     provider_mock = MagicMock()
-    provider_mock.encryption_sdk = 'aws_encryption_sdk'
+    provider_mock.encryption_sdk = "aws_encryption_sdk"
 
     entry = SecretManagerEntry(
         session=session,
         kms_arn=KEY_ARN,
-        data={
-            'name': 'secret1',
-            'value': 'MyPlainText'
-        },
+        data={"name": "secret1", "value": "MyPlainText"},
         provider=provider_mock,
-        cipher_text=None
+        cipher_text=None,
     )
 
-    assert entry.encrypt() == 'SecretData'
-    mock_encrypt.assert_called_once_with(session, 'MyPlainText', KEY_ARN)
+    assert entry.encrypt() == "SecretData"
+    mock_encrypt.assert_called_once_with(session, "MyPlainText", KEY_ARN)
 
 
-@patch('aws_secrets.miscellaneous.crypto.decrypt')
+@patch("aws_secrets.miscellaneous.crypto.decrypt")
 def test_decrypt_aws_encryption_sdk(mock_decrypt):
     """
-        Should decrypt the cipher text using AWS Encryption SDK
+    Should decrypt the cipher text using AWS Encryption SDK
     """
 
-    mock_decrypt.return_value = 'PlainTextData'
+    mock_decrypt.return_value = "PlainTextData"
 
-    session = boto3.Session(region_name='us-east-1')
+    session = boto3.Session(region_name="us-east-1")
     provider_mock = MagicMock()
-    provider_mock.encryption_sdk = 'aws_encryption_sdk'
+    provider_mock.encryption_sdk = "aws_encryption_sdk"
 
     entry = SecretManagerEntry(
         session=session,
         kms_arn=KEY_ARN,
-        data={
-            'name': 'secret1'
-        },
+        data={"name": "secret1"},
         provider=provider_mock,
-        cipher_text='SecretData'
+        cipher_text="SecretData",
     )
 
-    assert entry.decrypt() == 'PlainTextData'
-    mock_decrypt.assert_called_once_with(session, 'SecretData', KEY_ARN)
+    assert entry.decrypt() == "PlainTextData"
+    mock_decrypt.assert_called_once_with(session, "SecretData", KEY_ARN)

--- a/tests/config/providers/ssm/test_entry.py
+++ b/tests/config/providers/ssm/test_entry.py
@@ -7,470 +7,474 @@ from botocore.stub import Stubber
 from aws_secrets.config.providers.ssm.entry import SSMParameterEntry
 from aws_secrets.helpers.catch_exceptions import CLIError
 
-KEY_ARN = 'arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab'
-KEY_ARN1 = 'arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab1'
+KEY_ARN = "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
+KEY_ARN1 = (
+    "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab1"
+)
 
 
-@patch('aws_secrets.miscellaneous.kms.encrypt')
+@patch("aws_secrets.miscellaneous.kms.encrypt")
 def test_encrypt_secure_string(mock_encrypt):
     """
-        Should encrypt the raw value
+    Should encrypt the raw value
     """
 
-    mock_encrypt.return_value = b'SecretData'
+    mock_encrypt.return_value = b"SecretData"
 
-    session = boto3.Session(region_name='us-east-1')
+    session = boto3.Session(region_name="us-east-1")
     provider_mock = MagicMock()
-    provider_mock.encryption_sdk = 'boto3'
+    provider_mock.encryption_sdk = "boto3"
 
     entry = SSMParameterEntry(
         session=session,
         kms_arn=KEY_ARN,
-        data={
-            'name': 'ssm-param',
-            'type': 'SecureString',
-            'value': 'MyPlainText'
-        },
+        data={"name": "ssm-param", "type": "SecureString", "value": "MyPlainText"},
         cipher_text=None,
-        provider=provider_mock
+        provider=provider_mock,
     )
 
-    assert entry.encrypt() == 'SecretData'
-    mock_encrypt.assert_called_once_with(session, 'MyPlainText', KEY_ARN)
+    assert entry.encrypt() == "SecretData"
+    mock_encrypt.assert_called_once_with(session, "MyPlainText", KEY_ARN)
 
 
-@patch('aws_secrets.miscellaneous.kms.encrypt')
+@patch("aws_secrets.miscellaneous.kms.encrypt")
 def test_encrypt_secure_string_already_encrypted(mock_encrypt):
     """
-        Should not encrypt the raw value when the value is already encrypted
+    Should not encrypt the raw value when the value is already encrypted
     """
 
-    session = boto3.Session(region_name='us-east-1')
+    session = boto3.Session(region_name="us-east-1")
     provider_mock = MagicMock()
-    provider_mock.encryption_sdk = 'boto3'
+    provider_mock.encryption_sdk = "boto3"
 
     entry = SSMParameterEntry(
         session=session,
         kms_arn=KEY_ARN,
-        data={
-            'name': 'ssm-param',
-            'type': 'SecureString'
-        },
-        cipher_text='SecretData',
-        provider=provider_mock
+        data={"name": "ssm-param", "type": "SecureString"},
+        cipher_text="SecretData",
+        provider=provider_mock,
     )
 
-    assert entry.encrypt() == 'SecretData'
+    assert entry.encrypt() == "SecretData"
     mock_encrypt.assert_not_called()
 
 
-@patch('aws_secrets.miscellaneous.kms.encrypt')
+@patch("aws_secrets.miscellaneous.kms.encrypt")
 def test_encrypt_invalid_type(mock_encrypt):
     """
-        Should not encrypt when the type is invalid
+    Should not encrypt when the type is invalid
     """
 
-    session = boto3.Session(region_name='us-east-1')
+    session = boto3.Session(region_name="us-east-1")
     provider_mock = MagicMock()
-    provider_mock.encryption_sdk = 'boto3'
+    provider_mock.encryption_sdk = "boto3"
 
     with pytest.raises(CLIError) as error:
         SSMParameterEntry(
             session=session,
             kms_arn=KEY_ARN,
-            data={
-                'name': 'ssm-param',
-                'type': 'Invalid'
-            },
-            cipher_text='SecretData',
-            provider=provider_mock
+            data={"name": "ssm-param", "type": "Invalid"},
+            cipher_text="SecretData",
+            provider=provider_mock,
         )
 
         assert "'Invalid' is not one of ['String', 'SecureString']" in str(error.value)
         mock_encrypt.assert_not_called()
 
 
-@patch('aws_secrets.miscellaneous.kms.decrypt')
+@patch("aws_secrets.miscellaneous.kms.decrypt")
 def test_decrypt_secure_string(mock_decrypt):
     """
-        Should decrypt the cipher text
+    Should decrypt the cipher text
     """
 
-    mock_decrypt.return_value = b'PlainTextData'
+    mock_decrypt.return_value = b"PlainTextData"
 
-    session = boto3.Session(region_name='us-east-1')
+    session = boto3.Session(region_name="us-east-1")
     provider_mock = MagicMock()
-    provider_mock.encryption_sdk = 'boto3'
+    provider_mock.encryption_sdk = "boto3"
 
     entry = SSMParameterEntry(
         session=session,
         kms_arn=KEY_ARN,
-        data={
-            'name': 'ssm-param',
-            'type': 'SecureString'
-        },
-        cipher_text='SecretData',
-        provider=provider_mock
+        data={"name": "ssm-param", "type": "SecureString"},
+        cipher_text="SecretData",
+        provider=provider_mock,
     )
 
-    assert entry.decrypt() == 'PlainTextData'
-    mock_decrypt.assert_called_once_with(session, 'SecretData', KEY_ARN)
+    assert entry.decrypt() == "PlainTextData"
+    mock_decrypt.assert_called_once_with(session, "SecretData", KEY_ARN)
 
 
-@patch('aws_secrets.miscellaneous.kms.decrypt')
+@patch("aws_secrets.miscellaneous.kms.decrypt")
+def test_decrypt_secure_string_format(mock_decrypt):
+    """
+    Should decrypt the cipher text
+    """
+
+    mock_decrypt.return_value = b"{\"key\": \"PlainTextData\"}"
+
+    session = boto3.Session(region_name="us-east-1")
+    provider_mock = MagicMock()
+    provider_mock.encryption_sdk = "boto3"
+
+    entry = SSMParameterEntry(
+        session=session,
+        kms_arn=KEY_ARN,
+        data={"name": "ssm-param", "type": "SecureString"},
+        cipher_text="SecretData",
+        provider=provider_mock,
+    )
+
+    assert entry.decrypt(format=True) == "{\n  \"key\": \"PlainTextData\"\n}"
+    mock_decrypt.assert_called_once_with(session, "SecretData", KEY_ARN)
+
+
+@patch("aws_secrets.miscellaneous.kms.decrypt")
 def test_decrypt_secure_string_with_value_data(mock_decrypt):
     """
-        Should decrypt the cipher text
+    Should decrypt the cipher text
     """
 
-    mock_decrypt.return_value = b'PlainTextData'
+    mock_decrypt.return_value = b"PlainTextData"
 
-    session = boto3.Session(region_name='us-east-1')
+    session = boto3.Session(region_name="us-east-1")
     provider_mock = MagicMock()
-    provider_mock.encryption_sdk = 'boto3'
+    provider_mock.encryption_sdk = "boto3"
 
     entry = SSMParameterEntry(
         session=session,
         kms_arn=KEY_ARN,
-        data={
-            'name': 'ssm-param',
-            'type': 'SecureString',
-            'value': 'SecretData'
-        },
+        data={"name": "ssm-param", "type": "SecureString", "value": "SecretData"},
         cipher_text=None,
-        provider=provider_mock
+        provider=provider_mock,
     )
 
-    assert entry.decrypt() == 'PlainTextData'
-    mock_decrypt.assert_called_once_with(session, 'SecretData', KEY_ARN)
+    assert entry.decrypt() == "PlainTextData"
+    mock_decrypt.assert_called_once_with(session, "SecretData", KEY_ARN)
 
 
-@patch('aws_secrets.miscellaneous.kms.decrypt')
+@patch("aws_secrets.miscellaneous.kms.decrypt")
 def test_decrypt_string_type(mock_decrypt):
     """
-        Should not decrypt when the type is not SecureString
+    Should not decrypt when the type is not SecureString
     """
 
-    mock_decrypt.return_value = b'PlainTextData'
+    mock_decrypt.return_value = b"PlainTextData"
 
-    session = boto3.Session(region_name='us-east-1')
+    session = boto3.Session(region_name="us-east-1")
     provider_mock = MagicMock()
-    provider_mock.encryption_sdk = 'boto3'
+    provider_mock.encryption_sdk = "boto3"
 
     entry = SSMParameterEntry(
         session=session,
         kms_arn=KEY_ARN,
-        data={
-            'name': 'ssm-param',
-            'type': 'String',
-            'value': 'PlainTextData'
-        },
+        data={"name": "ssm-param", "type": "String", "value": "PlainTextData"},
         cipher_text=None,
-        provider=provider_mock
+        provider=provider_mock,
     )
 
-    assert entry.decrypt() == 'PlainTextData'
+    assert entry.decrypt() == "PlainTextData"
     mock_decrypt.assert_not_called()
 
 
-@patch('aws_secrets.miscellaneous.kms.decrypt')
+@patch("aws_secrets.miscellaneous.kms.decrypt")
 def test_create_default_kms(mock_decrypt):
     """
-        Should create the SSM parameter in the AWS environment
+    Should create the SSM parameter in the AWS environment
     """
-    client = boto3.client('ssm')
-    mock_decrypt.return_value = b'PlainTextData'
+    client = boto3.client("ssm")
+    mock_decrypt.return_value = b"PlainTextData"
 
-    with patch.object(boto3.Session, 'client') as mock_client:
+    with patch.object(boto3.Session, "client") as mock_client:
         with Stubber(client) as stubber:
-            name = 'ssm-param'
-            description = 'ssm description'
-            ssm_type = 'SecureString'
+            name = "ssm-param"
+            description = "ssm description"
+            ssm_type = "SecureString"
 
             mock_client.return_value = client
-            stubber.add_response('put_parameter', {}, {
-                'Name': name,
-                'Description': description,
-                'Type': ssm_type,
-                'Value': 'PlainTextData',
-                'Tier': 'Standard',
-                'Tags': []
-            })
+            stubber.add_response(
+                "put_parameter",
+                {},
+                {
+                    "Name": name,
+                    "Description": description,
+                    "Type": ssm_type,
+                    "Value": "PlainTextData",
+                    "Tier": "Standard",
+                    "Tags": [],
+                },
+            )
 
-            session = boto3.Session(region_name='us-east-1')
+            session = boto3.Session(region_name="us-east-1")
             provider_mock = MagicMock()
-            provider_mock.encryption_sdk = 'boto3'
+            provider_mock.encryption_sdk = "boto3"
 
             entry = SSMParameterEntry(
                 session=session,
-                cipher_text='SecretData',
+                cipher_text="SecretData",
                 kms_arn=KEY_ARN,
-                data={
-                    'name': name,
-                    'description': description,
-                    'type': ssm_type
-                },
-                provider=provider_mock
+                data={"name": name, "description": description, "type": ssm_type},
+                provider=provider_mock,
             )
 
             entry.create()
             assert True
-            mock_decrypt.assert_called_once_with(session, 'SecretData', KEY_ARN)
+            mock_decrypt.assert_called_once_with(session, "SecretData", KEY_ARN)
 
 
-@patch('aws_secrets.miscellaneous.kms.decrypt')
+@patch("aws_secrets.miscellaneous.kms.decrypt")
 def test_create_custom_kms(mock_decrypt):
     """
-        Should create the SSM parameter in the AWS environment
+    Should create the SSM parameter in the AWS environment
     """
-    client = boto3.client('ssm')
-    mock_decrypt.return_value = b'PlainTextData'
+    client = boto3.client("ssm")
+    mock_decrypt.return_value = b"PlainTextData"
 
-    with patch.object(boto3.Session, 'client') as mock_client:
+    with patch.object(boto3.Session, "client") as mock_client:
         with Stubber(client) as stubber:
-            name = 'ssm-param'
-            description = 'ssm description'
-            ssm_type = 'SecureString'
+            name = "ssm-param"
+            description = "ssm description"
+            ssm_type = "SecureString"
 
             mock_client.return_value = client
-            stubber.add_response('put_parameter', {}, {
-                'Name': name,
-                'Description': description,
-                'Type': ssm_type,
-                'Value': 'PlainTextData',
-                'Tier': 'Standard',
-                'KeyId': KEY_ARN,
-                'Tags': []
-            })
+            stubber.add_response(
+                "put_parameter",
+                {},
+                {
+                    "Name": name,
+                    "Description": description,
+                    "Type": ssm_type,
+                    "Value": "PlainTextData",
+                    "Tier": "Standard",
+                    "KeyId": KEY_ARN,
+                    "Tags": [],
+                },
+            )
 
-            session = boto3.Session(region_name='us-east-1')
+            session = boto3.Session(region_name="us-east-1")
             provider_mock = MagicMock()
-            provider_mock.encryption_sdk = 'boto3'
+            provider_mock.encryption_sdk = "boto3"
 
             entry = SSMParameterEntry(
                 session=session,
-                cipher_text='SecretData',
+                cipher_text="SecretData",
                 kms_arn=KEY_ARN,
                 data={
-                    'name': name,
-                    'description': description,
-                    'type': ssm_type,
-                    'kms': KEY_ARN
+                    "name": name,
+                    "description": description,
+                    "type": ssm_type,
+                    "kms": KEY_ARN,
                 },
-                provider=provider_mock
+                provider=provider_mock,
             )
 
             entry.create()
             assert True
-            mock_decrypt.assert_called_once_with(session, 'SecretData', KEY_ARN)
+            mock_decrypt.assert_called_once_with(session, "SecretData", KEY_ARN)
 
 
-@patch('aws_secrets.miscellaneous.kms.decrypt')
+@patch("aws_secrets.miscellaneous.kms.decrypt")
 def test_update_default_kms_without_tag_changes(mock_decrypt):
     """
-        Should update the SSM parameter in the AWS environment without tag changes
+    Should update the SSM parameter in the AWS environment without tag changes
     """
-    client = boto3.client('ssm')
-    mock_decrypt.return_value = b'PlainTextData'
+    client = boto3.client("ssm")
+    mock_decrypt.return_value = b"PlainTextData"
 
-    with patch.object(boto3.Session, 'client') as mock_client:
+    with patch.object(boto3.Session, "client") as mock_client:
         with Stubber(client) as stubber:
-            name = 'ssm-param'
-            description = 'ssm description'
-            ssm_type = 'SecureString'
+            name = "ssm-param"
+            description = "ssm description"
+            ssm_type = "SecureString"
 
             mock_client.return_value = client
-            stubber.add_response('put_parameter', {}, {
-                'Name': name,
-                'Description': description,
-                'Type': ssm_type,
-                'Value': 'PlainTextData',
-                'Tier': 'Standard',
-                'Overwrite': True
-            })
-            stubber.add_response('remove_tags_from_resource', {}, {
-                'ResourceType': 'Parameter',
-                'ResourceId': name,
-                'TagKeys': []
-            })
+            stubber.add_response(
+                "put_parameter",
+                {},
+                {
+                    "Name": name,
+                    "Description": description,
+                    "Type": ssm_type,
+                    "Value": "PlainTextData",
+                    "Tier": "Standard",
+                    "Overwrite": True,
+                },
+            )
+            stubber.add_response(
+                "remove_tags_from_resource",
+                {},
+                {"ResourceType": "Parameter", "ResourceId": name, "TagKeys": []},
+            )
 
-            session = boto3.Session(region_name='us-east-1')
+            session = boto3.Session(region_name="us-east-1")
             provider_mock = MagicMock()
-            provider_mock.encryption_sdk = 'boto3'
+            provider_mock.encryption_sdk = "boto3"
 
             entry = SSMParameterEntry(
                 session=session,
-                cipher_text='SecretData',
+                cipher_text="SecretData",
                 kms_arn=KEY_ARN,
-                data={
-                    'name': name,
-                    'description': description,
-                    'type': ssm_type
-                },
-                provider=provider_mock
+                data={"name": name, "description": description, "type": ssm_type},
+                provider=provider_mock,
             )
 
-            entry.update({
-                'ChangesList': []
-            })
+            entry.update({"ChangesList": []})
             assert True
-            mock_decrypt.assert_called_once_with(session, 'SecretData', KEY_ARN)
+            mock_decrypt.assert_called_once_with(session, "SecretData", KEY_ARN)
 
 
-@patch('aws_secrets.miscellaneous.kms.decrypt')
+@patch("aws_secrets.miscellaneous.kms.decrypt")
 def test_update_custom_kms_without_tag_changes(mock_decrypt):
     """
-        Should update the SSM parameter in the AWS environment without tag changes
+    Should update the SSM parameter in the AWS environment without tag changes
     """
-    client = boto3.client('ssm')
-    mock_decrypt.return_value = b'PlainTextData'
+    client = boto3.client("ssm")
+    mock_decrypt.return_value = b"PlainTextData"
 
-    with patch.object(boto3.Session, 'client') as mock_client:
+    with patch.object(boto3.Session, "client") as mock_client:
         with Stubber(client) as stubber:
-            name = 'ssm-param'
-            description = 'ssm description'
-            ssm_type = 'SecureString'
+            name = "ssm-param"
+            description = "ssm description"
+            ssm_type = "SecureString"
 
             mock_client.return_value = client
-            stubber.add_response('put_parameter', {}, {
-                'Name': name,
-                'Description': description,
-                'Type': ssm_type,
-                'Value': 'PlainTextData',
-                'Tier': 'Standard',
-                'KeyId': KEY_ARN,
-                'Overwrite': True
-            })
-            stubber.add_response('remove_tags_from_resource', {}, {
-                'ResourceType': 'Parameter',
-                'ResourceId': name,
-                'TagKeys': []
-            })
+            stubber.add_response(
+                "put_parameter",
+                {},
+                {
+                    "Name": name,
+                    "Description": description,
+                    "Type": ssm_type,
+                    "Value": "PlainTextData",
+                    "Tier": "Standard",
+                    "KeyId": KEY_ARN,
+                    "Overwrite": True,
+                },
+            )
+            stubber.add_response(
+                "remove_tags_from_resource",
+                {},
+                {"ResourceType": "Parameter", "ResourceId": name, "TagKeys": []},
+            )
 
-            session = boto3.Session(region_name='us-east-1')
+            session = boto3.Session(region_name="us-east-1")
             provider_mock = MagicMock()
-            provider_mock.encryption_sdk = 'boto3'
+            provider_mock.encryption_sdk = "boto3"
 
             entry = SSMParameterEntry(
                 session=session,
-                cipher_text='SecretData',
+                cipher_text="SecretData",
                 kms_arn=KEY_ARN,
                 data={
-                    'name': name,
-                    'description': description,
-                    'type': ssm_type,
-                    'kms': KEY_ARN
+                    "name": name,
+                    "description": description,
+                    "type": ssm_type,
+                    "kms": KEY_ARN,
                 },
-                provider=provider_mock
+                provider=provider_mock,
             )
 
-            entry.update({
-                'ChangesList': []
-            })
+            entry.update({"ChangesList": []})
             assert True
-            mock_decrypt.assert_called_once_with(session, 'SecretData', KEY_ARN)
+            mock_decrypt.assert_called_once_with(session, "SecretData", KEY_ARN)
 
 
-@patch('aws_secrets.miscellaneous.kms.decrypt')
+@patch("aws_secrets.miscellaneous.kms.decrypt")
 def test_update_default_kms_with_tag_changes(mock_decrypt):
     """
-        Should update the SSM parameter in the AWS environment with tag changes
+    Should update the SSM parameter in the AWS environment with tag changes
     """
-    client = boto3.client('ssm')
-    mock_decrypt.return_value = b'PlainTextData'
+    client = boto3.client("ssm")
+    mock_decrypt.return_value = b"PlainTextData"
 
-    with patch.object(boto3.Session, 'client') as mock_client:
+    with patch.object(boto3.Session, "client") as mock_client:
         with Stubber(client) as stubber:
-            name = 'ssm-param'
-            description = 'ssm description'
-            ssm_type = 'SecureString'
+            name = "ssm-param"
+            description = "ssm description"
+            ssm_type = "SecureString"
 
             mock_client.return_value = client
-            stubber.add_response('put_parameter', {}, {
-                'Name': name,
-                'Description': description,
-                'Type': ssm_type,
-                'Value': 'PlainTextData',
-                'Tier': 'Standard',
-                'Overwrite': True
-            })
-            stubber.add_response('remove_tags_from_resource', {}, {
-                'ResourceType': 'Parameter',
-                'ResourceId': name,
-                'TagKeys': ['Test']
-            })
-            stubber.add_response('add_tags_to_resource', {}, {
-                'ResourceType': 'Parameter',
-                'ResourceId': name,
-                'Tags': [{
-                    'Key': 'Test',
-                    'Value': 'New'
-                }]
-            })
+            stubber.add_response(
+                "put_parameter",
+                {},
+                {
+                    "Name": name,
+                    "Description": description,
+                    "Type": ssm_type,
+                    "Value": "PlainTextData",
+                    "Tier": "Standard",
+                    "Overwrite": True,
+                },
+            )
+            stubber.add_response(
+                "remove_tags_from_resource",
+                {},
+                {"ResourceType": "Parameter", "ResourceId": name, "TagKeys": ["Test"]},
+            )
+            stubber.add_response(
+                "add_tags_to_resource",
+                {},
+                {
+                    "ResourceType": "Parameter",
+                    "ResourceId": name,
+                    "Tags": [{"Key": "Test", "Value": "New"}],
+                },
+            )
 
-            session = boto3.Session(region_name='us-east-1')
+            session = boto3.Session(region_name="us-east-1")
             provider_mock = MagicMock()
-            provider_mock.encryption_sdk = 'boto3'
+            provider_mock.encryption_sdk = "boto3"
 
             entry = SSMParameterEntry(
                 session=session,
-                cipher_text='SecretData',
+                cipher_text="SecretData",
                 kms_arn=KEY_ARN,
                 data={
-                    'name': name,
-                    'description': description,
-                    'type': ssm_type,
-                    'tags': {
-                        'Test': 'New'
-                    }
+                    "name": name,
+                    "description": description,
+                    "type": ssm_type,
+                    "tags": {"Test": "New"},
                 },
-                provider=provider_mock
+                provider=provider_mock,
             )
 
-            entry.update({
-                'ChangesList': [{
-                    'Key': 'Tags',
-                    'OldValue': [{
-                        'Key': 'Test',
-                        'Value': 'Old'
-                    }]
-                }]
-            })
+            entry.update(
+                {
+                    "ChangesList": [
+                        {"Key": "Tags", "OldValue": [{"Key": "Test", "Value": "Old"}]}
+                    ]
+                }
+            )
             assert True
-            mock_decrypt.assert_called_once_with(session, 'SecretData', KEY_ARN)
+            mock_decrypt.assert_called_once_with(session, "SecretData", KEY_ARN)
 
 
 def test_delete():
     """
-        Should delete the SSM parameter in the AWS environment
+    Should delete the SSM parameter in the AWS environment
     """
-    client = boto3.client('ssm')
+    client = boto3.client("ssm")
 
-    with patch.object(boto3.Session, 'client') as mock_client:
+    with patch.object(boto3.Session, "client") as mock_client:
         with Stubber(client) as stubber:
-            name = 'ssm-param'
-            description = 'ssm description'
-            ssm_type = 'SecureString'
+            name = "ssm-param"
+            description = "ssm description"
+            ssm_type = "SecureString"
 
             mock_client.return_value = client
-            stubber.add_response('delete_parameter', {}, {
-                'Name': name
-            })
+            stubber.add_response("delete_parameter", {}, {"Name": name})
 
-            session = boto3.Session(region_name='us-east-1')
+            session = boto3.Session(region_name="us-east-1")
             provider_mock = MagicMock()
-            provider_mock.encryption_sdk = 'boto3'
+            provider_mock.encryption_sdk = "boto3"
 
             entry = SSMParameterEntry(
                 session=session,
-                cipher_text='SecretData',
+                cipher_text="SecretData",
                 kms_arn=KEY_ARN,
-                data={
-                    'name': name,
-                    'description': description,
-                    'type': ssm_type
-                },
-                provider=provider_mock
+                data={"name": name, "description": description, "type": ssm_type},
+                provider=provider_mock,
             )
 
             entry.delete()
@@ -479,478 +483,456 @@ def test_delete():
 
 def test_calculate_changes_with_parameter_not_exists():
     """
-        Should calculate the changes between AWS resource and local resource
+    Should calculate the changes between AWS resource and local resource
 
-        Scenario:
-            - Parameter not exists
+    Scenario:
+        - Parameter not exists
     """
-    client = boto3.client('ssm')
+    client = boto3.client("ssm")
 
-    with patch.object(boto3.Session, 'client') as mock_client:
+    with patch.object(boto3.Session, "client") as mock_client:
         with Stubber(client) as stubber:
-            name = 'ssm-param'
-            description = 'ssm description'
-            ssm_type = 'SecureString'
+            name = "ssm-param"
+            description = "ssm description"
+            ssm_type = "SecureString"
 
             mock_client.return_value = client
-            stubber.add_response('describe_parameters', {
-                'Parameters': []
-            }, {
-                'ParameterFilters': [
-                    {
-                        'Key': 'Name',
-                        'Option': 'Equals',
-                        'Values': [name]
-                    }
-                ]
-            })
-
-            session = boto3.Session(region_name='us-east-1')
-            provider_mock = MagicMock()
-            provider_mock.encryption_sdk = 'boto3'
-            entry = SSMParameterEntry(
-                session=session,
-                cipher_text='SecretData',
-                kms_arn=KEY_ARN,
-                data={
-                    'name': name,
-                    'description': description,
-                    'type': ssm_type
+            stubber.add_response(
+                "describe_parameters",
+                {"Parameters": []},
+                {
+                    "ParameterFilters": [
+                        {"Key": "Name", "Option": "Equals", "Values": [name]}
+                    ]
                 },
-                provider=provider_mock
             )
 
-            assert entry.changes() == {
-                'Exists': False,
-                'ChangesList': []
-            }
+            session = boto3.Session(region_name="us-east-1")
+            provider_mock = MagicMock()
+            provider_mock.encryption_sdk = "boto3"
+            entry = SSMParameterEntry(
+                session=session,
+                cipher_text="SecretData",
+                kms_arn=KEY_ARN,
+                data={"name": name, "description": description, "type": ssm_type},
+                provider=provider_mock,
+            )
+
+            assert entry.changes() == {"Exists": False, "ChangesList": []}
 
 
-@patch('aws_secrets.miscellaneous.kms.decrypt')
+@patch("aws_secrets.miscellaneous.kms.decrypt")
 def test_calculate_changes_with_changes(mock_decrypt):
     """
-        Should calculate the changes between AWS resource and local resource
+    Should calculate the changes between AWS resource and local resource
 
-        Scenario:
-            - Parameter exists
-            - Value changed
-            - Description changed
-            - Type changed
-            - Tier changed
-            - Kms changed
-            - Tags changed
+    Scenario:
+        - Parameter exists
+        - Value changed
+        - Description changed
+        - Type changed
+        - Tier changed
+        - Kms changed
+        - Tags changed
     """
-    client = boto3.client('ssm')
-    mock_decrypt.return_value = b'PlainTextData'
+    client = boto3.client("ssm")
+    mock_decrypt.return_value = b"PlainTextData"
 
-    with patch.object(boto3.Session, 'client') as mock_client:
+    with patch.object(boto3.Session, "client") as mock_client:
         with Stubber(client) as stubber:
-            name = 'ssm-param'
-            description = 'ssm description'
-            ssm_type = 'SecureString'
+            name = "ssm-param"
+            description = "ssm description"
+            ssm_type = "SecureString"
 
             mock_client.return_value = client
-            stubber.add_response('describe_parameters', {
-                'Parameters': [{
-                    'Name': name,
-                    'Description': f'{description} CHANGED',
-                    'Type': 'String',
-                    'KeyId': KEY_ARN1,
-                    'Tier': 'Standard'
-                }]
-            }, {
-                'ParameterFilters': [
-                    {
-                        'Key': 'Name',
-                        'Option': 'Equals',
-                        'Values': [name]
-                    }
-                ]
-            })
-            stubber.add_response('get_parameter', {
-                'Parameter': {
-                    'Value': 'AWSData'
-                }
-            }, {
-                'Name': name,
-                'WithDecryption': False
-            })
-            stubber.add_response('list_tags_for_resource', {
-                'TagList': [{
-                    'Key': 'Test',
-                    'Value': 'Old'
-                }]
-            }, {
-                'ResourceType': 'Parameter',
-                'ResourceId': name
-            })
+            stubber.add_response(
+                "describe_parameters",
+                {
+                    "Parameters": [
+                        {
+                            "Name": name,
+                            "Description": f"{description} CHANGED",
+                            "Type": "String",
+                            "KeyId": KEY_ARN1,
+                            "Tier": "Standard",
+                        }
+                    ]
+                },
+                {
+                    "ParameterFilters": [
+                        {"Key": "Name", "Option": "Equals", "Values": [name]}
+                    ]
+                },
+            )
+            stubber.add_response(
+                "get_parameter",
+                {"Parameter": {"Value": "AWSData"}},
+                {"Name": name, "WithDecryption": False},
+            )
+            stubber.add_response(
+                "list_tags_for_resource",
+                {"TagList": [{"Key": "Test", "Value": "Old"}]},
+                {"ResourceType": "Parameter", "ResourceId": name},
+            )
 
-            session = boto3.Session(region_name='us-east-1')
+            session = boto3.Session(region_name="us-east-1")
             provider_mock = MagicMock()
-            provider_mock.encryption_sdk = 'boto3'
+            provider_mock.encryption_sdk = "boto3"
             entry = SSMParameterEntry(
                 session=session,
-                cipher_text='SecretData',
+                cipher_text="SecretData",
                 kms_arn=KEY_ARN,
                 data={
-                    'name': name,
-                    'description': description,
-                    'type': ssm_type,
-                    'kms': KEY_ARN,
-                    'tier': 'Advanced',
-                    'tags': {
-                        'Test': 'New'
-                    }
+                    "name": name,
+                    "description": description,
+                    "type": ssm_type,
+                    "kms": KEY_ARN,
+                    "tier": "Advanced",
+                    "tags": {"Test": "New"},
                 },
-                provider=provider_mock
+                provider=provider_mock,
             )
 
             assert entry.changes() == {
-                'Exists': True,
-                'ChangesList': [{
-                    'HasChanges': True,
-                    'Key': 'Value',
-                    'OldValue': 'AWSData',
-                    'Replaceable': True,
-                    'Value': 'PlainTextData'
-                }, {
-                    'HasChanges': True,
-                    'Key': 'Description',
-                    'OldValue': 'ssm description CHANGED',
-                    'Replaceable': True,
-                    'Value': 'ssm description',
-                }, {
-                    'HasChanges': True,
-                    'Key': 'KeyId',
-                    'OldValue': KEY_ARN1,
-                    'Replaceable': True,
-                    'Value': KEY_ARN
-                }, {
-                    'HasChanges': True,
-                    'Key': 'Type',
-                    'OldValue': 'String',
-                    'Replaceable': False,
-                    'Value': 'SecureString'
-                }, {
-                    'HasChanges': True,
-                    'Key': 'Tier',
-                    'OldValue': 'Standard',
-                    'Replaceable': True,
-                    'Value': 'Advanced'
-                }, {
-                    'HasChanges': True,
-                    'Key': 'Tags',
-                    'OldValue': [{'Key': 'Test', 'Value': 'Old'}],
-                    'Replaceable': True,
-                    'Value': [{'Key': 'Test', 'Value': 'New'}],
-                }]
+                "Exists": True,
+                "ChangesList": [
+                    {
+                        "HasChanges": True,
+                        "Key": "Value",
+                        "OldValue": "AWSData",
+                        "Replaceable": True,
+                        "Value": "PlainTextData",
+                    },
+                    {
+                        "HasChanges": True,
+                        "Key": "Description",
+                        "OldValue": "ssm description CHANGED",
+                        "Replaceable": True,
+                        "Value": "ssm description",
+                    },
+                    {
+                        "HasChanges": True,
+                        "Key": "KeyId",
+                        "OldValue": KEY_ARN1,
+                        "Replaceable": True,
+                        "Value": KEY_ARN,
+                    },
+                    {
+                        "HasChanges": True,
+                        "Key": "Type",
+                        "OldValue": "String",
+                        "Replaceable": False,
+                        "Value": "SecureString",
+                    },
+                    {
+                        "HasChanges": True,
+                        "Key": "Tier",
+                        "OldValue": "Standard",
+                        "Replaceable": True,
+                        "Value": "Advanced",
+                    },
+                    {
+                        "HasChanges": True,
+                        "Key": "Tags",
+                        "OldValue": [{"Key": "Test", "Value": "Old"}],
+                        "Replaceable": True,
+                        "Value": [{"Key": "Test", "Value": "New"}],
+                    },
+                ],
             }
 
 
-@patch('aws_secrets.miscellaneous.kms.decrypt')
+@patch("aws_secrets.miscellaneous.kms.decrypt")
 def test_calculate_changes_with_tier_replaceable_false(mock_decrypt):
     """
-        Should calculate the changes between AWS resource and local resource
+    Should calculate the changes between AWS resource and local resource
 
-        Scenario:
-            - Parameter exists
-            - Value changed
-            - Description changed
-            - Type changed
-            - Tier changed and not replaceable
-            - Kms changed
-            - Tags changed
+    Scenario:
+        - Parameter exists
+        - Value changed
+        - Description changed
+        - Type changed
+        - Tier changed and not replaceable
+        - Kms changed
+        - Tags changed
     """
-    client = boto3.client('ssm')
-    mock_decrypt.return_value = b'PlainTextData'
+    client = boto3.client("ssm")
+    mock_decrypt.return_value = b"PlainTextData"
 
-    with patch.object(boto3.Session, 'client') as mock_client:
+    with patch.object(boto3.Session, "client") as mock_client:
         with Stubber(client) as stubber:
-            name = 'ssm-param'
-            description = 'ssm description'
-            ssm_type = 'SecureString'
+            name = "ssm-param"
+            description = "ssm description"
+            ssm_type = "SecureString"
 
             mock_client.return_value = client
-            stubber.add_response('describe_parameters', {
-                'Parameters': [{
-                    'Name': name,
-                    'Description': f'{description} CHANGED',
-                    'Type': 'String',
-                    'KeyId': KEY_ARN1,
-                    'Tier': 'Advanced'
-                }]
-            }, {
-                'ParameterFilters': [
-                    {
-                        'Key': 'Name',
-                        'Option': 'Equals',
-                        'Values': [name]
-                    }
-                ]
-            })
-            stubber.add_response('get_parameter', {
-                'Parameter': {
-                    'Value': 'AWSData'
-                }
-            }, {
-                'Name': name,
-                'WithDecryption': False
-            })
-            stubber.add_response('list_tags_for_resource', {
-                'TagList': [{
-                    'Key': 'Test',
-                    'Value': 'Old'
-                }]
-            }, {
-                'ResourceType': 'Parameter',
-                'ResourceId': name
-            })
+            stubber.add_response(
+                "describe_parameters",
+                {
+                    "Parameters": [
+                        {
+                            "Name": name,
+                            "Description": f"{description} CHANGED",
+                            "Type": "String",
+                            "KeyId": KEY_ARN1,
+                            "Tier": "Advanced",
+                        }
+                    ]
+                },
+                {
+                    "ParameterFilters": [
+                        {"Key": "Name", "Option": "Equals", "Values": [name]}
+                    ]
+                },
+            )
+            stubber.add_response(
+                "get_parameter",
+                {"Parameter": {"Value": "AWSData"}},
+                {"Name": name, "WithDecryption": False},
+            )
+            stubber.add_response(
+                "list_tags_for_resource",
+                {"TagList": [{"Key": "Test", "Value": "Old"}]},
+                {"ResourceType": "Parameter", "ResourceId": name},
+            )
 
-            session = boto3.Session(region_name='us-east-1')
+            session = boto3.Session(region_name="us-east-1")
             provider_mock = MagicMock()
-            provider_mock.encryption_sdk = 'boto3'
+            provider_mock.encryption_sdk = "boto3"
             entry = SSMParameterEntry(
                 session=session,
-                cipher_text='SecretData',
+                cipher_text="SecretData",
                 kms_arn=KEY_ARN,
                 data={
-                    'name': name,
-                    'description': description,
-                    'type': ssm_type,
-                    'kms': KEY_ARN,
-                    'tier': 'Standard',
-                    'tags': {
-                        'Test': 'New'
-                    }
+                    "name": name,
+                    "description": description,
+                    "type": ssm_type,
+                    "kms": KEY_ARN,
+                    "tier": "Standard",
+                    "tags": {"Test": "New"},
                 },
-                provider=provider_mock
+                provider=provider_mock,
             )
 
             assert entry.changes() == {
-                'Exists': True,
-                'ChangesList': [{
-                    'HasChanges': True,
-                    'Key': 'Value',
-                    'OldValue': 'AWSData',
-                    'Replaceable': True,
-                    'Value': 'PlainTextData'
-                }, {
-                    'HasChanges': True,
-                    'Key': 'Description',
-                    'OldValue': 'ssm description CHANGED',
-                    'Replaceable': True,
-                    'Value': 'ssm description',
-                }, {
-                    'HasChanges': True,
-                    'Key': 'KeyId',
-                    'OldValue': KEY_ARN1,
-                    'Replaceable': True,
-                    'Value': KEY_ARN
-                }, {
-                    'HasChanges': True,
-                    'Key': 'Type',
-                    'OldValue': 'String',
-                    'Replaceable': False,
-                    'Value': 'SecureString'
-                }, {
-                    'HasChanges': True,
-                    'Key': 'Tier',
-                    'OldValue': 'Advanced',
-                    'Replaceable': False,
-                    'Value': 'Standard'
-                }, {
-                    'HasChanges': True,
-                    'Key': 'Tags',
-                    'OldValue': [{'Key': 'Test', 'Value': 'Old'}],
-                    'Replaceable': True,
-                    'Value': [{'Key': 'Test', 'Value': 'New'}],
-                }]
+                "Exists": True,
+                "ChangesList": [
+                    {
+                        "HasChanges": True,
+                        "Key": "Value",
+                        "OldValue": "AWSData",
+                        "Replaceable": True,
+                        "Value": "PlainTextData",
+                    },
+                    {
+                        "HasChanges": True,
+                        "Key": "Description",
+                        "OldValue": "ssm description CHANGED",
+                        "Replaceable": True,
+                        "Value": "ssm description",
+                    },
+                    {
+                        "HasChanges": True,
+                        "Key": "KeyId",
+                        "OldValue": KEY_ARN1,
+                        "Replaceable": True,
+                        "Value": KEY_ARN,
+                    },
+                    {
+                        "HasChanges": True,
+                        "Key": "Type",
+                        "OldValue": "String",
+                        "Replaceable": False,
+                        "Value": "SecureString",
+                    },
+                    {
+                        "HasChanges": True,
+                        "Key": "Tier",
+                        "OldValue": "Advanced",
+                        "Replaceable": False,
+                        "Value": "Standard",
+                    },
+                    {
+                        "HasChanges": True,
+                        "Key": "Tags",
+                        "OldValue": [{"Key": "Test", "Value": "Old"}],
+                        "Replaceable": True,
+                        "Value": [{"Key": "Test", "Value": "New"}],
+                    },
+                ],
             }
 
 
-@patch('aws_secrets.miscellaneous.kms.decrypt')
+@patch("aws_secrets.miscellaneous.kms.decrypt")
 def test_calculate_changes_without_changes(mock_decrypt):
     """
-        Should calculate the changes between AWS resource and local resource
+    Should calculate the changes between AWS resource and local resource
 
-        Scenario:
-            - Parameter exists
-            - Value not changed
-            - Description not changed
-            - Type not changed
-            - Tier not changed
-            - Kms not changed
-            - Tags not changed
+    Scenario:
+        - Parameter exists
+        - Value not changed
+        - Description not changed
+        - Type not changed
+        - Tier not changed
+        - Kms not changed
+        - Tags not changed
     """
-    client = boto3.client('ssm')
-    mock_decrypt.return_value = b'PlainTextData'
+    client = boto3.client("ssm")
+    mock_decrypt.return_value = b"PlainTextData"
 
-    with patch.object(boto3.Session, 'client') as mock_client:
+    with patch.object(boto3.Session, "client") as mock_client:
         with Stubber(client) as stubber:
-            name = 'ssm-param'
-            description = 'ssm description'
-            ssm_type = 'SecureString'
+            name = "ssm-param"
+            description = "ssm description"
+            ssm_type = "SecureString"
 
             mock_client.return_value = client
-            stubber.add_response('describe_parameters', {
-                'Parameters': [{
-                    'Name': name,
-                    'Description': description,
-                    'Type': 'SecureString',
-                    'KeyId': KEY_ARN,
-                    'Tier': 'Standard'
-                }]
-            }, {
-                'ParameterFilters': [
-                    {
-                        'Key': 'Name',
-                        'Option': 'Equals',
-                        'Values': [name]
-                    }
-                ]
-            })
-            stubber.add_response('get_parameter', {
-                'Parameter': {
-                    'Value': 'PlainTextData'
-                }
-            }, {
-                'Name': name,
-                'WithDecryption': True
-            })
-            stubber.add_response('list_tags_for_resource', {
-                'TagList': [{
-                    'Key': 'Test',
-                    'Value': 'New'
-                }]
-            }, {
-                'ResourceType': 'Parameter',
-                'ResourceId': name
-            })
-
-            session = boto3.Session(region_name='us-east-1')
-            provider_mock = MagicMock()
-            provider_mock.encryption_sdk = 'boto3'
-
-            entry = SSMParameterEntry(
-                session=session,
-                cipher_text='SecretData',
-                kms_arn=KEY_ARN,
-                data={
-                    'name': name,
-                    'description': description,
-                    'type': ssm_type,
-                    'kms': KEY_ARN,
-                    'tags': {
-                        'Test': 'New'
-                    }
+            stubber.add_response(
+                "describe_parameters",
+                {
+                    "Parameters": [
+                        {
+                            "Name": name,
+                            "Description": description,
+                            "Type": "SecureString",
+                            "KeyId": KEY_ARN,
+                            "Tier": "Standard",
+                        }
+                    ]
                 },
-                provider=provider_mock
+                {
+                    "ParameterFilters": [
+                        {"Key": "Name", "Option": "Equals", "Values": [name]}
+                    ]
+                },
+            )
+            stubber.add_response(
+                "get_parameter",
+                {"Parameter": {"Value": "PlainTextData"}},
+                {"Name": name, "WithDecryption": True},
+            )
+            stubber.add_response(
+                "list_tags_for_resource",
+                {"TagList": [{"Key": "Test", "Value": "New"}]},
+                {"ResourceType": "Parameter", "ResourceId": name},
             )
 
-            assert entry.changes() == {
-                'Exists': True,
-                'ChangesList': []
-            }
-
-
-@patch('aws_secrets.miscellaneous.kms.decrypt')
-def test_create_advanced_tier(mock_decrypt):
-    """
-        Should create the SSM parameter in the AWS environment
-    """
-    client = boto3.client('ssm')
-    mock_decrypt.return_value = b'PlainTextData'
-
-    with patch.object(boto3.Session, 'client') as mock_client:
-        with Stubber(client) as stubber:
-            name = 'ssm-param'
-            description = 'ssm description'
-            ssm_type = 'SecureString'
-
-            mock_client.return_value = client
-            stubber.add_response('put_parameter', {}, {
-                'Name': name,
-                'Description': description,
-                'Type': ssm_type,
-                'Value': 'PlainTextData',
-                'Tier': 'Advanced',
-                'KeyId': KEY_ARN,
-                'Tags': []
-            })
-
-            session = boto3.Session(region_name='us-east-1')
+            session = boto3.Session(region_name="us-east-1")
             provider_mock = MagicMock()
-            provider_mock.encryption_sdk = 'boto3'
+            provider_mock.encryption_sdk = "boto3"
 
             entry = SSMParameterEntry(
                 session=session,
-                cipher_text='SecretData',
+                cipher_text="SecretData",
                 kms_arn=KEY_ARN,
                 data={
-                    'name': name,
-                    'description': description,
-                    'type': ssm_type,
-                    'tier': 'Advanced',
-                    'kms': KEY_ARN
+                    "name": name,
+                    "description": description,
+                    "type": ssm_type,
+                    "kms": KEY_ARN,
+                    "tags": {"Test": "New"},
                 },
-                provider=provider_mock
+                provider=provider_mock,
+            )
+
+            assert entry.changes() == {"Exists": True, "ChangesList": []}
+
+
+@patch("aws_secrets.miscellaneous.kms.decrypt")
+def test_create_advanced_tier(mock_decrypt):
+    """
+    Should create the SSM parameter in the AWS environment
+    """
+    client = boto3.client("ssm")
+    mock_decrypt.return_value = b"PlainTextData"
+
+    with patch.object(boto3.Session, "client") as mock_client:
+        with Stubber(client) as stubber:
+            name = "ssm-param"
+            description = "ssm description"
+            ssm_type = "SecureString"
+
+            mock_client.return_value = client
+            stubber.add_response(
+                "put_parameter",
+                {},
+                {
+                    "Name": name,
+                    "Description": description,
+                    "Type": ssm_type,
+                    "Value": "PlainTextData",
+                    "Tier": "Advanced",
+                    "KeyId": KEY_ARN,
+                    "Tags": [],
+                },
+            )
+
+            session = boto3.Session(region_name="us-east-1")
+            provider_mock = MagicMock()
+            provider_mock.encryption_sdk = "boto3"
+
+            entry = SSMParameterEntry(
+                session=session,
+                cipher_text="SecretData",
+                kms_arn=KEY_ARN,
+                data={
+                    "name": name,
+                    "description": description,
+                    "type": ssm_type,
+                    "tier": "Advanced",
+                    "kms": KEY_ARN,
+                },
+                provider=provider_mock,
             )
 
             entry.create()
             assert True
-            mock_decrypt.assert_called_once_with(session, 'SecretData', KEY_ARN)
+            mock_decrypt.assert_called_once_with(session, "SecretData", KEY_ARN)
 
 
-@patch('aws_secrets.miscellaneous.crypto.encrypt')
+@patch("aws_secrets.miscellaneous.crypto.encrypt")
 def test_encrypt_secure_string_aws_encryption_sdk(mock_encrypt):
     """
-        Should encrypt the raw value using AWS Encryption SDK
+    Should encrypt the raw value using AWS Encryption SDK
     """
 
-    mock_encrypt.return_value = 'SecretData'
+    mock_encrypt.return_value = "SecretData"
 
-    session = boto3.Session(region_name='us-east-1')
+    session = boto3.Session(region_name="us-east-1")
     provider_mock = MagicMock()
-    provider_mock.encryption_sdk = 'aws_encryption_sdk'
+    provider_mock.encryption_sdk = "aws_encryption_sdk"
 
     entry = SSMParameterEntry(
         session=session,
         kms_arn=KEY_ARN,
-        data={
-            'name': 'ssm-param',
-            'type': 'SecureString',
-            'value': 'MyPlainText'
-        },
+        data={"name": "ssm-param", "type": "SecureString", "value": "MyPlainText"},
         cipher_text=None,
-        provider=provider_mock
+        provider=provider_mock,
     )
 
-    assert entry.encrypt() == 'SecretData'
-    mock_encrypt.assert_called_once_with(session, 'MyPlainText', KEY_ARN)
+    assert entry.encrypt() == "SecretData"
+    mock_encrypt.assert_called_once_with(session, "MyPlainText", KEY_ARN)
 
 
-@patch('aws_secrets.miscellaneous.crypto.decrypt')
+@patch("aws_secrets.miscellaneous.crypto.decrypt")
 def test_decrypt_secure_string_aws_encryption_sdk(mock_decrypt):
     """
-        Should decrypt the cipher text using AWS encryption SDK
+    Should decrypt the cipher text using AWS encryption SDK
     """
 
-    mock_decrypt.return_value = 'PlainTextData'
+    mock_decrypt.return_value = "PlainTextData"
 
-    session = boto3.Session(region_name='us-east-1')
+    session = boto3.Session(region_name="us-east-1")
     provider_mock = MagicMock()
-    provider_mock.encryption_sdk = 'aws_encryption_sdk'
+    provider_mock.encryption_sdk = "aws_encryption_sdk"
 
     entry = SSMParameterEntry(
         session=session,
         kms_arn=KEY_ARN,
-        data={
-            'name': 'ssm-param',
-            'type': 'SecureString'
-        },
-        cipher_text='SecretData',
-        provider=provider_mock
+        data={"name": "ssm-param", "type": "SecureString"},
+        cipher_text="SecretData",
+        provider=provider_mock,
     )
 
-    assert entry.decrypt() == 'PlainTextData'
-    mock_decrypt.assert_called_once_with(session, 'SecretData', KEY_ARN)
+    assert entry.decrypt() == "PlainTextData"
+    mock_decrypt.assert_called_once_with(session, "SecretData", KEY_ARN)

--- a/tests/config/test_config_reader.py
+++ b/tests/config/test_config_reader.py
@@ -1,7 +1,8 @@
 from unittest.mock import patch
 
 from aws_secrets.config.config_reader import ConfigReader
-from aws_secrets.config.providers.secretsmanager.provider import SecretsManagerProvider
+from aws_secrets.config.providers.secretsmanager.provider import \
+    SecretsManagerProvider
 from aws_secrets.config.providers.ssm.provider import SSMProvider
 from aws_secrets.miscellaneous import session
 from aws_secrets.tags.cmd import CmdTag
@@ -146,7 +147,7 @@ parameters:
       value: 'PlainTextData'
     - name: 'ssm2'
       type: 'SecureString'
-      value: !cmd "value"
+      value: !cmd value
 secrets:
     - name: 'secret1'
       value: 'PlainTextData'
@@ -161,21 +162,22 @@ secrets:
         assert conf_data.read() == f"""kms:
   arn: {KEY_ARN}
 parameters:
-- name: ssm1
-  type: SecureString
-- name: ssm2
-  type: SecureString
-  value: !cmd 'value'
+  - name: ssm1
+    type: SecureString
+  - name: ssm2
+    type: SecureString
+    value: !cmd value
 secrets:
-- name: secret1
+  - name: secret1
 secrets_file: ./config.secrets.yaml
 """
 
     with open('config.secrets.yaml', 'r') as secrets_data:
-        assert secrets_data.read() == """parameters:
-- name: ssm1
-  value: SecretData
+        assert secrets_data.read() == """\
 secrets:
-- name: secret1
-  value: SecretData
+  - name: secret1
+    value: SecretData
+parameters:
+  - name: ssm1
+    value: SecretData
 """

--- a/tests/representers/test_literal.py
+++ b/tests/representers/test_literal.py
@@ -1,17 +1,15 @@
+from io import StringIO
 
-import yaml
-from aws_secrets.representers.literal import Literal, literal_presenter
+from aws_secrets.representers.literal import Literal
+from aws_secrets.yaml import yaml
 
 
 def test_literal_yaml():
     """
-        Should resolve YAML literal strings
+    Should resolve YAML literal strings
     """
 
-    yaml.SafeDumper.add_representer(Literal, literal_presenter)
+    string_stream = StringIO()
+    yaml.dump({"key": Literal("UNIT TESTS")}, string_stream)
 
-    data = yaml.safe_dump({
-        'key': Literal('UNIT TESTS')
-    })
-
-    assert data == 'key: |-\n  UNIT TESTS\n'
+    assert string_stream.getvalue() == "key: |-\n  UNIT TESTS\n"

--- a/tests/tags/test_cmd.py
+++ b/tests/tags/test_cmd.py
@@ -1,337 +1,324 @@
 import subprocess
+from io import StringIO
 from unittest.mock import ANY, patch
 
 import pytest
-import yaml
+
 from aws_secrets.helpers.catch_exceptions import CLIError
 from aws_secrets.miscellaneous import session
-from aws_secrets.tags.cmd import CmdTag
+from aws_secrets.yaml import yaml
 
 
-@patch('subprocess.run')
+@patch("subprocess.run")
 def test_cmd_yaml_tag(mock_run):
     """
-        Should execute the command and resolve the value
+    Should execute the command and resolve the value
     """
-    mock_run.return_value.stdout = 'myvalue'
+    mock_run.return_value.stdout = "myvalue"
 
-    yaml.SafeLoader.add_constructor('!cmd', CmdTag.from_yaml)
-    yaml.SafeDumper.add_multi_representer(CmdTag, CmdTag.to_yaml)
-
-    data = yaml.safe_load("""
+    data = yaml.load("""
 key: !cmd "echo 'hello'"
 """)
 
-    assert 'myvalue' == str(data['key'])
-    mock_run.assert_called_once_with("echo 'hello'".split(" "), stdout=subprocess.PIPE, encoding='utf-8')
+    assert "myvalue" == str(data["key"])
+    mock_run.assert_called_once_with(
+        "echo 'hello'".split(" "), stdout=subprocess.PIPE, encoding="utf-8"
+    )
 
 
 def test_cmd_yaml_tag_dump():
     """
-        Should generate the YAML correctly
+    Should generate the YAML correctly
     """
-    yaml.SafeLoader.add_constructor('!cmd', CmdTag.from_yaml)
-    yaml.SafeDumper.add_multi_representer(CmdTag, CmdTag.to_yaml)
-
-    data = yaml.safe_load("""
+    data = yaml.load("""
 key: !cmd "echo 'hello'"
 """)
 
-    assert yaml.safe_dump(data) == "key: !cmd 'echo ''hello'''\n"
+    string_stream = StringIO()
+    yaml.dump(data, string_stream)
+
+    assert string_stream.getvalue() == "key: !cmd echo 'hello'\n"
 
 
-@patch('subprocess.run')
+@patch("subprocess.run")
 def test_cmd_yaml_tag_with_session_provider_profile(mock_run):
     """
-        Should execute the command and resolve the value that has the session provider
+    Should execute the command and resolve the value that has the session provider
     """
-    mock_run.return_value.stdout = 'myvalue'
+    mock_run.return_value.stdout = "myvalue"
 
-    yaml.SafeLoader.add_constructor('!cmd', CmdTag.from_yaml)
-    yaml.SafeDumper.add_multi_representer(CmdTag, CmdTag.to_yaml)
+    session.aws_profile = "fake-profile"
 
-    session.aws_profile = 'fake-profile'
-
-    data = yaml.safe_load("""
+    data = yaml.load("""
 key: !cmd "echo '${session:profile}'"
 """)
 
-    assert 'myvalue' == str(data['key'])
+    assert "myvalue" == str(data["key"])
 
     session.aws_profile = None
-    mock_run.assert_called_once_with("echo 'fake-profile'".split(" "), stdout=subprocess.PIPE, encoding='utf-8')
+    mock_run.assert_called_once_with(
+        "echo 'fake-profile'".split(" "), stdout=subprocess.PIPE, encoding="utf-8"
+    )
 
 
-@patch('subprocess.run')
+@patch("subprocess.run")
 def test_cmd_yaml_tag_with_session_provider_region(mock_run):
     """
-        Should execute the command and resolve the value that has the session provider
+    Should execute the command and resolve the value that has the session provider
     """
-    mock_run.return_value.stdout = 'myvalue'
+    mock_run.return_value.stdout = "myvalue"
 
-    yaml.SafeLoader.add_constructor('!cmd', CmdTag.from_yaml)
-    yaml.SafeDumper.add_multi_representer(CmdTag, CmdTag.to_yaml)
+    session.aws_region = "us-east-1"
 
-    session.aws_region = 'us-east-1'
-
-    data = yaml.safe_load("""
+    data = yaml.load("""
 key: !cmd "echo '${session:region}'"
 """)
 
-    assert 'myvalue' == str(data['key'])
+    assert "myvalue" == str(data["key"])
 
     session.aws_region = None
-    mock_run.assert_called_once_with("echo 'us-east-1'".split(" "), stdout=subprocess.PIPE, encoding='utf-8')
+    mock_run.assert_called_once_with(
+        "echo 'us-east-1'".split(" "), stdout=subprocess.PIPE, encoding="utf-8"
+    )
 
 
-@patch('subprocess.run')
+@patch("subprocess.run")
 def test_cmd_yaml_tag_with_session_provider_no_region(mock_run):
     """
-        Should execute the command and resolve the value that has the session provider
+    Should execute the command and resolve the value that has the session provider
     """
-    mock_run.return_value.stdout = 'myvalue'
-
-    yaml.SafeLoader.add_constructor('!cmd', CmdTag.from_yaml)
-    yaml.SafeDumper.add_multi_representer(CmdTag, CmdTag.to_yaml)
+    mock_run.return_value.stdout = "myvalue"
 
     session.aws_region = None
 
-    data = yaml.safe_load("""
+    data = yaml.load("""
 key: !cmd "echo '${session:region}'"
 """)
 
-    assert 'myvalue' == str(data['key'])
-    mock_run.assert_called_once_with("echo ''".split(" "), stdout=subprocess.PIPE, encoding='utf-8')
+    assert "myvalue" == str(data["key"])
+    mock_run.assert_called_once_with(
+        "echo ''".split(" "), stdout=subprocess.PIPE, encoding="utf-8"
+    )
 
 
-@patch('subprocess.run')
+@patch("subprocess.run")
 def test_cmd_yaml_tag_with_session_provider_default_region(mock_run):
     """
-        Should execute the command and resolve the value that has the session provider
+    Should execute the command and resolve the value that has the session provider
     """
-    mock_run.return_value.stdout = 'myvalue'
-
-    yaml.SafeLoader.add_constructor('!cmd', CmdTag.from_yaml)
-    yaml.SafeDumper.add_multi_representer(CmdTag, CmdTag.to_yaml)
+    mock_run.return_value.stdout = "myvalue"
 
     session.aws_region = None
 
-    data = yaml.safe_load("""
+    data = yaml.load("""
 key: !cmd "echo '${session:region, us-east-1}'"
 """)
 
-    assert 'myvalue' == str(data['key'])
-    mock_run.assert_called_once_with("echo 'us-east-1'".split(" "), stdout=subprocess.PIPE, encoding='utf-8')
+    assert "myvalue" == str(data["key"])
+    mock_run.assert_called_once_with(
+        "echo 'us-east-1'".split(" "), stdout=subprocess.PIPE, encoding="utf-8"
+    )
 
 
-@patch('subprocess.run')
+@patch("subprocess.run")
 def test_cmd_yaml_tag_with_session_provider_invalid_prop(mock_run):
     """
-        Should throw an exception when the session provider has in invalid property
+    Should throw an exception when the session provider has in invalid property
     """
-    yaml.SafeLoader.add_constructor('!cmd', CmdTag.from_yaml)
-    yaml.SafeDumper.add_multi_representer(CmdTag, CmdTag.to_yaml)
-
     session.aws_region = None
 
-    data = yaml.safe_load("""
+    data = yaml.load("""
 key: !cmd "echo '${session:dump}'"
 """)
 
     with pytest.raises(CLIError) as error:
-        print(str(data['key']))
+        print(str(data["key"]))
 
-    assert 'Property `dump` is not supported, ' + \
-        f'provider `session` just supports {str(["profile", "region"])} properties' in str(error.value)
+    assert (
+        "Property `dump` is not supported, "
+        + f'provider `session` just supports {str(["profile", "region"])} properties'
+        in str(error.value)
+    )
 
     mock_run.assert_not_called()
 
 
-@patch('subprocess.run')
+@patch("subprocess.run")
 def test_cmd_yaml_tag_with_invalid_provider(mock_run):
     """
-        Should throw an exception when the provider is invalid
+    Should throw an exception when the provider is invalid
     """
-    yaml.SafeLoader.add_constructor('!cmd', CmdTag.from_yaml)
-    yaml.SafeDumper.add_multi_representer(CmdTag, CmdTag.to_yaml)
-
     session.aws_region = None
 
-    data = yaml.safe_load("""
+    data = yaml.load("""
 key: !cmd "echo '${dump:dump}'"
 """)
 
     with pytest.raises(CLIError) as error:
-        print(str(data['key']))
+        print(str(data["key"]))
 
-    assert 'Provider dump is not supported' in str(error.value)
+    assert "Provider dump is not supported" in str(error.value)
 
     mock_run.assert_not_called()
 
 
-@patch('subprocess.run')
-@patch('aws_secrets.miscellaneous.cloudformation.get_output_value')
+@patch("subprocess.run")
+@patch("aws_secrets.miscellaneous.cloudformation.get_output_value")
 def test_cmd_yaml_tag_with_cf_provider(mock_get_output_value, mock_run):
     """
-        Should execute the command and resolve the value that has the cf provider
+    Should execute the command and resolve the value that has the cf provider
     """
-    mock_run.return_value.stdout = 'myvalue'
-    mock_get_output_value.return_value = 'stack-output'
+    mock_run.return_value.stdout = "myvalue"
+    mock_get_output_value.return_value = "stack-output"
 
-    yaml.SafeLoader.add_constructor('!cmd', CmdTag.from_yaml)
-    yaml.SafeDumper.add_multi_representer(CmdTag, CmdTag.to_yaml)
-
-    data = yaml.safe_load("""
+    data = yaml.load("""
 key: !cmd "echo '${cf:stack.output}'"
 """)
 
-    assert 'myvalue' == str(data['key'])
-    mock_run.assert_called_once_with("echo 'stack-output'".split(" "), stdout=subprocess.PIPE, encoding='utf-8')
-    mock_get_output_value.assert_called_once_with(ANY, 'stack', 'output')
+    assert "myvalue" == str(data["key"])
+    mock_run.assert_called_once_with(
+        "echo 'stack-output'".split(" "), stdout=subprocess.PIPE, encoding="utf-8"
+    )
+    mock_get_output_value.assert_called_once_with(ANY, "stack", "output")
 
 
-@patch('subprocess.run')
-@patch('aws_secrets.miscellaneous.cloudformation.get_output_value')
+@patch("subprocess.run")
+@patch("aws_secrets.miscellaneous.cloudformation.get_output_value")
 def test_cmd_yaml_tag_with_cf_provider_default_value(mock_get_output_value, mock_run):
     """
-        Should execute the command and resolve the value that has the cf provider
+    Should execute the command and resolve the value that has the cf provider
     """
-    mock_run.return_value.stdout = 'myvalue'
+    mock_run.return_value.stdout = "myvalue"
     mock_get_output_value.return_value = None
 
-    yaml.SafeLoader.add_constructor('!cmd', CmdTag.from_yaml)
-    yaml.SafeDumper.add_multi_representer(CmdTag, CmdTag.to_yaml)
-
-    data = yaml.safe_load("""
+    data = yaml.load("""
 key: !cmd "echo '${cf:stack.output, stack-output}'"
 """)
 
-    assert 'myvalue' == str(data['key'])
-    mock_run.assert_called_once_with("echo 'stack-output'".split(" "), stdout=subprocess.PIPE, encoding='utf-8')
-    mock_get_output_value.assert_called_once_with(ANY, 'stack', 'output')
+    assert "myvalue" == str(data["key"])
+    mock_run.assert_called_once_with(
+        "echo 'stack-output'".split(" "), stdout=subprocess.PIPE, encoding="utf-8"
+    )
+    mock_get_output_value.assert_called_once_with(ANY, "stack", "output")
 
 
-@patch('subprocess.run')
+@patch("subprocess.run")
 def test_cmd_yaml_tag_with_aws_provider_profile(mock_run):
     """
-        Should execute the command and resolve the value that has the aws provider
+    Should execute the command and resolve the value that has the aws provider
     """
-    mock_run.return_value.stdout = 'myvalue'
+    mock_run.return_value.stdout = "myvalue"
 
-    yaml.SafeLoader.add_constructor('!cmd', CmdTag.from_yaml)
-    yaml.SafeDumper.add_multi_representer(CmdTag, CmdTag.to_yaml)
+    session.aws_profile = "fake-profile"
 
-    session.aws_profile = 'fake-profile'
-
-    data = yaml.safe_load("""
+    data = yaml.load("""
 key: !cmd "echo '${aws:profile}'"
 """)
 
-    assert 'myvalue' == str(data['key'])
+    assert "myvalue" == str(data["key"])
 
     session.aws_profile = None
-    mock_run.assert_called_once_with("echo '--profile fake-profile'".split(" "),
-                                     stdout=subprocess.PIPE, encoding='utf-8')
+    mock_run.assert_called_once_with(
+        "echo '--profile fake-profile'".split(" "),
+        stdout=subprocess.PIPE,
+        encoding="utf-8",
+    )
 
 
-@patch('subprocess.run')
+@patch("subprocess.run")
 def test_cmd_yaml_tag_with_aws_provider_profile_default_value(mock_run):
     """
-        Should execute the command and resolve the value that has the aws provider
+    Should execute the command and resolve the value that has the aws provider
     """
-    mock_run.return_value.stdout = 'myvalue'
-
-    yaml.SafeLoader.add_constructor('!cmd', CmdTag.from_yaml)
-    yaml.SafeDumper.add_multi_representer(CmdTag, CmdTag.to_yaml)
+    mock_run.return_value.stdout = "myvalue"
 
     session.aws_profile = None
 
-    data = yaml.safe_load("""
+    data = yaml.load("""
 key: !cmd "echo '${aws:profile, fake-profile}'"
 """)
 
-    assert 'myvalue' == str(data['key'])
-    mock_run.assert_called_once_with("echo '--profile fake-profile'".split(" "),
-                                     stdout=subprocess.PIPE, encoding='utf-8')
+    assert "myvalue" == str(data["key"])
+    mock_run.assert_called_once_with(
+        "echo '--profile fake-profile'".split(" "),
+        stdout=subprocess.PIPE,
+        encoding="utf-8",
+    )
 
 
-@patch('subprocess.run')
+@patch("subprocess.run")
 def test_cmd_yaml_tag_with_aws_provider_profile_none(mock_run):
     """
-        Should execute the command and resolve the value that has the aws provider
+    Should execute the command and resolve the value that has the aws provider
     """
-    mock_run.return_value.stdout = 'myvalue'
-
-    yaml.SafeLoader.add_constructor('!cmd', CmdTag.from_yaml)
-    yaml.SafeDumper.add_multi_representer(CmdTag, CmdTag.to_yaml)
+    mock_run.return_value.stdout = "myvalue"
 
     session.aws_profile = None
 
-    data = yaml.safe_load("""
+    data = yaml.load("""
 key: !cmd "echo '${aws:profile}'"
 """)
 
-    assert 'myvalue' == str(data['key'])
-    mock_run.assert_called_once_with("echo ''".split(" "), stdout=subprocess.PIPE, encoding='utf-8')
+    assert "myvalue" == str(data["key"])
+    mock_run.assert_called_once_with(
+        "echo ''".split(" "), stdout=subprocess.PIPE, encoding="utf-8"
+    )
 
 
-@patch('subprocess.run')
+@patch("subprocess.run")
 def test_cmd_yaml_tag_with_aws_provider_region(mock_run):
     """
-        Should execute the command and resolve the value that has the aws provider
+    Should execute the command and resolve the value that has the aws provider
     """
-    mock_run.return_value.stdout = 'myvalue'
+    mock_run.return_value.stdout = "myvalue"
 
-    yaml.SafeLoader.add_constructor('!cmd', CmdTag.from_yaml)
-    yaml.SafeDumper.add_multi_representer(CmdTag, CmdTag.to_yaml)
+    session.aws_region = "us-east-1"
 
-    session.aws_region = 'us-east-1'
-
-    data = yaml.safe_load("""
+    data = yaml.load("""
 key: !cmd "echo '${aws:region}'"
 """)
 
-    assert 'myvalue' == str(data['key'])
+    assert "myvalue" == str(data["key"])
 
     session.aws_region = None
-    mock_run.assert_called_once_with("echo '--region us-east-1'".split(" "), stdout=subprocess.PIPE, encoding='utf-8')
+    mock_run.assert_called_once_with(
+        "echo '--region us-east-1'".split(" "), stdout=subprocess.PIPE, encoding="utf-8"
+    )
 
 
-@patch('subprocess.run')
+@patch("subprocess.run")
 def test_cmd_yaml_tag_with_aws_provider_region_default_value(mock_run):
     """
-        Should execute the command and resolve the value that has the aws provider
+    Should execute the command and resolve the value that has the aws provider
     """
-    mock_run.return_value.stdout = 'myvalue'
-
-    yaml.SafeLoader.add_constructor('!cmd', CmdTag.from_yaml)
-    yaml.SafeDumper.add_multi_representer(CmdTag, CmdTag.to_yaml)
+    mock_run.return_value.stdout = "myvalue"
 
     session.aws_region = None
 
-    data = yaml.safe_load("""
+    data = yaml.load("""
 key: !cmd "echo '${aws:region, us-east-1}'"
 """)
 
-    assert 'myvalue' == str(data['key'])
-    mock_run.assert_called_once_with("echo '--region us-east-1'".split(" "), stdout=subprocess.PIPE, encoding='utf-8')
+    assert "myvalue" == str(data["key"])
+    mock_run.assert_called_once_with(
+        "echo '--region us-east-1'".split(" "), stdout=subprocess.PIPE, encoding="utf-8"
+    )
 
 
-@patch('subprocess.run')
+@patch("subprocess.run")
 def test_cmd_yaml_tag_with_aws_provider_region_none(mock_run):
     """
-        Should execute the command and resolve the value that has the aws provider
+    Should execute the command and resolve the value that has the aws provider
     """
-    mock_run.return_value.stdout = 'myvalue'
-
-    yaml.SafeLoader.add_constructor('!cmd', CmdTag.from_yaml)
-    yaml.SafeDumper.add_multi_representer(CmdTag, CmdTag.to_yaml)
+    mock_run.return_value.stdout = "myvalue"
 
     session.aws_region = None
 
-    data = yaml.safe_load("""
+    data = yaml.load("""
 key: !cmd "echo '${aws:region}'"
 """)
 
-    assert 'myvalue' == str(data['key'])
-    mock_run.assert_called_once_with("echo ''".split(" "), stdout=subprocess.PIPE, encoding='utf-8')
+    assert "myvalue" == str(data["key"])
+    mock_run.assert_called_once_with(
+        "echo ''".split(" "), stdout=subprocess.PIPE, encoding="utf-8"
+    )

--- a/tests/tags/test_file.py
+++ b/tests/tags/test_file.py
@@ -1,56 +1,55 @@
+from io import StringIO
+
 import pytest
-import yaml
-from aws_secrets.tags.file import FileTag
+
 from aws_secrets.helpers.catch_exceptions import CLIError
+from aws_secrets.yaml import yaml
 
 
-@pytest.mark.parametrize("file_path,content", [
-    ('file.txt', "hello world"),
-    ('subdir/file.txt', "hello world2"),
-    ('../file.txt', "hello world3"),
-])
+@pytest.mark.parametrize(
+    "file_path,content",
+    [
+        ("file.txt", "hello world"),
+        ("subdir/file.txt", "hello world2"),
+        ("../file.txt", "hello world3"),
+    ],
+)
 def test_file_tag(fs, file_path, content):
     """
-        Should resolve the file in the same folder
+    Should resolve the file in the same folder
     """
     fs.create_file(file_path, contents=content)
 
-    yaml.SafeLoader.add_constructor('!file', FileTag.from_yaml)
-    yaml.SafeDumper.add_multi_representer(FileTag, FileTag.to_yaml)
-
-    data = yaml.safe_load(f"""
+    data = yaml.load(f"""
 key: !file {file_path}
 """)
 
-    assert str(data['key']) == content
+    assert str(data["key"]) == content
 
 
 def test_file_tag_not_found(fs):
     """
-        Should resolve the file in the same folder
+    Should resolve the file in the same folder
     """
-    yaml.SafeLoader.add_constructor('!file', FileTag.from_yaml)
-    yaml.SafeDumper.add_multi_representer(FileTag, FileTag.to_yaml)
-
-    data = yaml.safe_load("""
+    data = yaml.load("""
 key: !file not_found.txt
 """)
 
     with pytest.raises(CLIError) as error:
-        print(str(data['key']))
+        print(str(data["key"]))
 
     assert str(error.value) == "File '/not_found.txt' not found"
 
 
 def test_cmd_yaml_tag_dump():
     """
-        Should generate the YAML correctly
+    Should generate the YAML correctly
     """
-    yaml.SafeLoader.add_constructor('!file', FileTag.from_yaml)
-    yaml.SafeDumper.add_multi_representer(FileTag, FileTag.to_yaml)
-
-    data = yaml.safe_load("""
+    data = yaml.load("""
 key: !file hello.txt
 """)
 
-    assert yaml.safe_dump(data) == "key: !file 'hello.txt'\n"
+    string_stream = StringIO()
+    yaml.dump(data, string_stream)
+
+    assert string_stream.getvalue() == "key: !file hello.txt\n"

--- a/tests/tags/test_output_stack.py
+++ b/tests/tags/test_output_stack.py
@@ -1,98 +1,79 @@
+from io import StringIO
 from unittest.mock import ANY, patch
 
 import pytest
-import yaml
 
 from aws_secrets.helpers.catch_exceptions import CLIError
-from aws_secrets.tags.output_stack import OutputStackTag
+from aws_secrets.yaml import yaml
 
 
-@patch('aws_secrets.miscellaneous.cloudformation.get_output_value')
-def test_cf_output_yaml_tag(
-    mock_get_output_value
-):
+@patch("aws_secrets.miscellaneous.cloudformation.get_output_value")
+def test_cf_output_yaml_tag(mock_get_output_value):
     """
-        Should resolve the cloudformation stack output value
+    Should resolve the cloudformation stack output value
     """
-    output = 'myvalue'
+    output = "myvalue"
 
     mock_get_output_value.return_value = output
 
-    yaml.SafeLoader.add_constructor('!cf_output', OutputStackTag.from_yaml)
-    yaml.SafeDumper.add_multi_representer(
-        OutputStackTag, OutputStackTag.to_yaml)
-
-    data = yaml.safe_load("""
+    data = yaml.load("""
 key: !cf_output stack.output
 """)
 
-    assert str(data['key']) == output
-    mock_get_output_value.assert_called_once_with(ANY, 'stack', 'output')
+    assert str(data["key"]) == output
+    mock_get_output_value.assert_called_once_with(ANY, "stack", "output")
 
 
-@patch('aws_secrets.miscellaneous.cloudformation.get_output_value')
-def test_cf_output_yaml_tag_with_region(
-    mock_get_output_value
-):
+@patch("aws_secrets.miscellaneous.cloudformation.get_output_value")
+def test_cf_output_yaml_tag_with_region(mock_get_output_value):
     """
-        Should resolve the cloudformation stack output value
+    Should resolve the cloudformation stack output value
     """
-    output = 'myvalue'
+    output = "myvalue"
 
     mock_get_output_value.return_value = output
 
-    yaml.SafeLoader.add_constructor('!cf_output', OutputStackTag.from_yaml)
-    yaml.SafeDumper.add_multi_representer(
-        OutputStackTag, OutputStackTag.to_yaml)
-
-    data = yaml.safe_load("""
+    data = yaml.load("""
 key: !cf_output stack.output.region
 """)
 
-    assert str(data['key']) == output
-    mock_get_output_value.assert_called_once_with(ANY, 'stack', 'output')
+    assert str(data["key"]) == output
+    mock_get_output_value.assert_called_once_with(ANY, "stack", "output")
 
 
-@patch('aws_secrets.miscellaneous.cloudformation.get_output_value')
-def test_cf_output_yaml_tag_invalid_format(
-    mock_get_output_value
-):
+@patch("aws_secrets.miscellaneous.cloudformation.get_output_value")
+def test_cf_output_yaml_tag_invalid_format(mock_get_output_value):
     """
-        Should throw an exception when resolve the cloudformation stack output value
+    Should throw an exception when resolve the cloudformation stack output value
     """
-    output = 'myvalue'
+    output = "myvalue"
 
     mock_get_output_value.return_value = output
 
-    yaml.SafeLoader.add_constructor('!cf_output', OutputStackTag.from_yaml)
-    yaml.SafeDumper.add_multi_representer(
-        OutputStackTag, OutputStackTag.to_yaml)
-
-    data = yaml.safe_load("""
+    data = yaml.load("""
 key: !cf_output stack
 """)
 
     with pytest.raises(CLIError) as error:
-        print(str(data['key']))
+        print(str(data["key"]))
 
     assert (
-        'value stack is invalid, the correct way to '
-        'fill this information is <stack-name>.<output-name> '
-        'or <stack-name>.<output-name>.<aws_region>'
+        "value stack is invalid, the correct way to "
+        "fill this information is <stack-name>.<output-name> "
+        "or <stack-name>.<output-name>.<aws_region>"
     ) == str(error.value)
     mock_get_output_value.assert_not_called()
 
 
 def test_cf_output_yaml_tag_dump():
     """
-        Should generate the correct YAML file using the !cf_output
+    Should generate the correct YAML file using the !cf_output
     """
-    yaml.SafeLoader.add_constructor('!cf_output', OutputStackTag.from_yaml)
-    yaml.SafeDumper.add_multi_representer(
-        OutputStackTag, OutputStackTag.to_yaml)
-
-    data = yaml.safe_load("""
+    data = yaml.load("""
 key: !cf_output stack.output
 """)
 
-    assert "key: !cf_output 'stack.output'\n" == yaml.safe_dump(data)
+    string_stream = StringIO()
+    yaml.dump(data, string_stream)
+
+    assert "key: !cf_output stack.output\n" == string_stream.getvalue()


### PR DESCRIPTION
#### Description

This PR improves the `aws-secrets set-secret` and `aws-secrets set-secret` CLI commands to use [prompt toolkit](https://python-prompt-toolkit.readthedocs.io/en/master/) library.

In this new version, all the arguments (`--name`, `--type`, `--description`) now are optional, and if the value is not provided the CLI will prompt a question in the terminal.

it also used the current value as the default value so the user can update the values instead of first resolve the full value from the `aws-secrets view-secret` command and then updating the value.

This PR also migrates from `pyyaml` to `ruamel.yaml`, which improves

- List indentation
- Keep the order of the properties
- Keep comments in the YAML file

#### Checklist

- [x] Update Documentation
- [x] Update CHANGELOG
- [x] Update Functions/Classes Docstrings
- [x] Update unit tests
