### PR TITLE
feat: add `--show-diff` to deploy command

### DIFF
--- a/aws_secrets/cli/deploy.py
+++ b/aws_secrets/cli/deploy.py
@@ -2,23 +2,31 @@ import logging
 from typing import Optional
 
 import click
+from click.core import Context
+
 from aws_secrets.config.config_reader import ConfigReader
 from aws_secrets.helpers.catch_exceptions import catch_exceptions
 from aws_secrets.miscellaneous import session
-from click.core import Context
 
 logger = logging.getLogger(__name__)
 
 
-@click.command(name='deploy', help='Deploy resource changes')
-@click.option('-e', '--env-file', help="Environment YAML file", type=click.Path(), required=True)
-@click.option('--filter-pattern', help="Filter Pattern", type=str)
-@click.option('--dry-run', help="Execution without apply the changes on the environment", is_flag=True)
-@click.option('--confirm', help="Confirm prompt before apply the changes", is_flag=True)
-@click.option('--only-secrets', help="Deploy only AWS Secrets", is_flag=True)
-@click.option('--only-parameters', help="Deploy only SSM Parameters", is_flag=True)
-@click.option('--profile', help="AWS Profile", envvar='AWS_PROFILE')
-@click.option('--region', help="AWS Region", envvar='AWS_REGION')
+@click.command(name="deploy", help="Deploy resource changes")
+@click.option(
+    "-e", "--env-file", help="Environment YAML file", type=click.Path(), required=True
+)
+@click.option("--filter-pattern", help="Filter Pattern", type=str)
+@click.option(
+    "--dry-run",
+    help="Execution without apply the changes on the environment",
+    is_flag=True,
+)
+@click.option("--confirm", help="Confirm prompt before apply the changes", is_flag=True)
+@click.option("--only-secrets", help="Deploy only AWS Secrets", is_flag=True)
+@click.option("--only-parameters", help="Deploy only SSM Parameters", is_flag=True)
+@click.option("--show-diff", help="Show the diff of the changes", is_flag=True)
+@click.option("--profile", help="AWS Profile", envvar="AWS_PROFILE")
+@click.option("--region", help="AWS Region", envvar="AWS_REGION")
 @click.pass_context
 @catch_exceptions
 def deploy(
@@ -29,33 +37,35 @@ def deploy(
     confirm: bool,
     only_secrets: bool,
     only_parameters: bool,
+    show_diff: bool,
     profile: Optional[str],
-    region: Optional[str]
+    region: Optional[str],
 ):
     """
-        Deploy CLI Commmand `aws-secrets deploy --help`
+    Deploy CLI Commmand `aws-secrets deploy --help`
 
-        Args:
-            ctx (`Context`): click context object
-            env_file (`str`): configuration YAML file
-            filter_pattern (`str`, optional): resource filter pattern
-            dry_run (`bool`): Dry run flag
-            confirm (`bool`): Flag to confirm the changes before apply
-            only_secrets (`bool`): Only deploy secrets
-            only_parameters (`bool`): Only deploy parameters
-            profile (`str`, optional): AWS Profile
-            region (`str`, optional): AWS Region
+    Args:
+        ctx (`Context`): click context object
+        env_file (`str`): configuration YAML file
+        filter_pattern (`str`, optional): resource filter pattern
+        dry_run (`bool`): Dry run flag
+        confirm (`bool`): Flag to confirm the changes before apply
+        only_secrets (`bool`): Only deploy secrets
+        only_parameters (`bool`): Only deploy parameters
+        show_diff (`bool`): Show the diff of the changes
+        profile (`str`, optional): AWS Profile
+        region (`str`, optional): AWS Region
     """
-    ctx.obj['config_file'] = env_file
+    ctx.obj["config_file"] = env_file
     session.aws_profile = profile
     session.aws_region = region
 
     config = ConfigReader(env_file)
 
     if only_secrets is True or (only_secrets is False and only_parameters is False):
-        provider = config.get_provider('secrets')
-        provider.deploy(filter_pattern, dry_run, confirm)
+        provider = config.get_provider("secrets")
+        provider.deploy(filter_pattern, dry_run, confirm, show_diff)
 
     if only_parameters is True or (only_secrets is False and only_parameters is False):
-        provider = config.get_provider('parameters')
-        provider.deploy(filter_pattern, dry_run, confirm)
+        provider = config.get_provider("parameters")
+        provider.deploy(filter_pattern, dry_run, confirm, show_diff)

--- a/aws_secrets/config/providers/__init__.py
+++ b/aws_secrets/config/providers/__init__.py
@@ -323,7 +323,7 @@ class BaseProvider:
 
     @abc.abstractmethod
     def deploy(
-        self, filter_pattern: Optional[str], dry_run: bool, confirm: bool
+        self, filter_pattern: Optional[str], dry_run: bool, confirm: bool, show_diff: bool
     ) -> None:
         """
         Deploy abstract definition

--- a/aws_secrets/config/providers/ssm/provider.py
+++ b/aws_secrets/config/providers/ssm/provider.py
@@ -9,25 +9,25 @@ from aws_secrets.representers.literal import Literal
 
 class SSMProvider(BaseProvider):
     """
-        AWS SSM Parameter Provider
+    AWS SSM Parameter Provider
 
-        This class handles the AWS SSM Parameter features:
-        - deploy the changes
-        - add new secrets
-        - update existing secrets
-        - decrypt/encrypt secrets
+    This class handles the AWS SSM Parameter features:
+    - deploy the changes
+    - add new secrets
+    - update existing secrets
+    - decrypt/encrypt secrets
 
-        Args:
-            config (`ConfigReader`): configuration file reader handler
+    Args:
+        config (`ConfigReader`): configuration file reader handler
 
-        Attributes:
-            logger (`Logger`): logger instance
-            global_tags (`Dict[str, str]`): map of global tags of the config file
-            session (`Session`): boto3 session object
-            kms_arn (`str`): Main Kms ARN
-            config_data (`Dict[str, Any]`): configuration parsed YAML
-            secrets_data (`Dict[str, Any]`): secrets parsed YAML
-            entries (`List[SSMParameterEntry]`): entries list
+    Attributes:
+        logger (`Logger`): logger instance
+        global_tags (`Dict[str, str]`): map of global tags of the config file
+        session (`Session`): boto3 session object
+        kms_arn (`str`): Main Kms ARN
+        config_data (`Dict[str, Any]`): configuration parsed YAML
+        secrets_data (`Dict[str, Any]`): secrets parsed YAML
+        entries (`List[SSMParameterEntry]`): entries list
     """
 
     def __init__(self, config) -> None:
@@ -35,16 +35,19 @@ class SSMProvider(BaseProvider):
 
     def load_entries(self) -> List[SSMParameterEntry]:
         """
-            The SSM parameter entries
-            location: config YAML file `parameters` list property
+        The SSM parameter entries
+        location: config YAML file `parameters` list property
 
-            Returns:
-                `List[SSMParameterEntry]`: list of entries
+        Returns:
+            `List[SSMParameterEntry]`: list of entries
         """
         result = []
-        self.logger.debug('Loading SSM Parameter entries')
+        self.logger.debug("Loading SSM Parameter entries")
         for param in self._get_data_entries():
-            secret_data = next((p for p in self._get_secrets_entries() if p['name'] == param['name']), {})
+            secret_data = next(
+                (p for p in self._get_secrets_entries() if p["name"] == param["name"]),
+                {},
+            )
 
             result.append(
                 SSMParameterEntry(
@@ -52,7 +55,7 @@ class SSMProvider(BaseProvider):
                     kms_arn=self.kms_arn,
                     data=param,
                     provider=self,
-                    cipher_text=secret_data.get('value', None)
+                    cipher_text=secret_data.get("value", None),
                 )
             )
 
@@ -60,47 +63,44 @@ class SSMProvider(BaseProvider):
 
     def decrypt(self) -> None:
         """
-            Decrypt the SSM parameter with `SecureString` type in the config file
+        Decrypt the SSM parameter with `SecureString` type in the config file
         """
-        self.logger.debug('Decrypting SSM Parameter entries')
+        self.logger.debug("Decrypting SSM Parameter entries")
         for item in self._get_data_entries():
-            item_obj = self.find(item['name'])
+            item_obj = self.find(item["name"])
 
             decrypted_value = item_obj.decrypt()
-            if isinstance(decrypted_value, str) and '\n' in decrypted_value:
-                item['value'] = Literal(decrypted_value)
+            if isinstance(decrypted_value, str) and "\n" in decrypted_value:
+                item["value"] = Literal(decrypted_value)
             else:
-                item['value'] = decrypted_value
+                item["value"] = decrypted_value
 
     def find(self, name: str) -> Optional[SSMParameterEntry]:
         """
-            Find an AWS SSM Parameter by name
+        Find an AWS SSM Parameter by name
 
-            Args:
-                name (`str`): entry name
+        Args:
+            name (`str`): entry name
 
-            Returns:
-                `SSMParameterEntry`, optional: parameter object or None
+        Returns:
+            `SSMParameterEntry`, optional: parameter object or None
         """
         self.logger.debug(f'Finding SSM Parameter entries by name "{name}"')
         return next((e for e in self.entries if e.name == name), None)
 
     def add(self, data: Dict[str, Any]) -> SSMParameterEntry:
         """
-            Add new AWS SSM Parameter
+        Add new AWS SSM Parameter
 
-            Args:
-                data (`Dict[str, Any]`): new parameter data
+        Args:
+            data (`Dict[str, Any]`): new parameter data
 
-            Returns:
-                `SSMParameterEntry`: parameter object
+        Returns:
+            `SSMParameterEntry`: parameter object
         """
         self.logger.debug(f'Add "{data["name"]}" SSM Parameter entry')
         entry = SSMParameterEntry(
-            session=self.session,
-            kms_arn=self.kms_arn,
-            provider=self,
-            data=data
+            session=self.session, kms_arn=self.kms_arn, provider=self, data=data
         )
         self.entries.append(entry)
         self._get_data_entries().append(data)
@@ -109,46 +109,44 @@ class SSMProvider(BaseProvider):
 
     def update(self, data: Dict[str, Any]) -> None:
         """
-            Update an existing parameter
+        Update an existing parameter
 
-            Args:
-                data (`Dict[str, Any]`): updated parameter data
+        Args:
+            data (`Dict[str, Any]`): updated parameter data
         """
         self.logger.debug(f'Updating "{data["name"]}" SSM Parameter entry')
 
         for idx, entry in enumerate(self.entries):
-            if entry.name == data['name']:
-                self.logger.debug('Updating entry in the entries list')
+            if entry.name == data["name"]:
+                self.logger.debug("Updating entry in the entries list")
                 self.entries[idx] = SSMParameterEntry(
-                    session=self.session,
-                    kms_arn=self.kms_arn,
-                    provider=self,
-                    data=data
+                    session=self.session, kms_arn=self.kms_arn, provider=self, data=data
                 )
 
         data_entries = self._get_data_entries()
         for idx, item_data in enumerate(data_entries):
-            if item_data['name'] == data['name']:
-                self.logger.debug('Updating entry data in the data entries list')
+            if item_data["name"] == data["name"]:
+                self.logger.debug("Updating entry data in the data entries list")
                 data_entries[idx] = {**item_data, **data}
 
     def deploy(
         self,
         filter_pattern: Optional[str],
         dry_run: bool,
-        confirm: bool
+        confirm: bool,
+        show_diff: bool,
     ) -> None:
         """
-            Deploy all AWS SSM Paremeter changes
+        Deploy all AWS SSM Paremeter changes
 
-            Args:
-                filter_pattern (`Optional[str]`): resource filter pattern
-                dry_run: (`bool`): dry run flag, just calculate the changes, but not apply them.
-                confirm: (`bool`): CLI confirmation prompt for the changes.
+        Args:
+            filter_pattern (`Optional[str]`): resource filter pattern
+            dry_run: (`bool`): dry run flag, just calculate the changes, but not apply them.
+            confirm: (`bool`): CLI confirmation prompt for the changes.
         """
         any_changes = False
         for parameter in self.filter(filter_pattern):
-            if self._deploy_parameter(parameter, dry_run, confirm):
+            if self._deploy_parameter(parameter, dry_run, confirm, show_diff):
                 any_changes = True
 
         if any_changes is False:
@@ -158,58 +156,72 @@ class SSMProvider(BaseProvider):
         self,
         parameter: SSMParameterEntry,
         dry_run: bool,
-        confirm: bool
+        confirm: bool,
+        show_diff: bool,
     ) -> bool:
         """
-            Deploy the parameter changes
+        Deploy the parameter changes
 
-            Args:
-                parameter (`SSMParameterEntry`): parameter entry object
-                dry_run: (`bool`): dry run flag, just calculate the changes, but not apply them.
-                confirm: (`bool`): CLI confirmation prompt for the changes.
+        Args:
+            parameter (`SSMParameterEntry`): parameter entry object
+            dry_run: (`bool`): dry run flag, just calculate the changes, but not apply them.
+            confirm: (`bool`): CLI confirmation prompt for the changes.
+            show_diff: (`bool`): show the diff of the changes
 
-            Returns:
-                `bool`: if changes are found.
+        Returns:
+            `bool`: if changes are found.
         """
         self.merge_tags(parameter)
         changes = parameter.changes()
 
-        if not changes['Exists']:
-            self.print_resource_name('Parameter', parameter.name)
+        if not changes["Exists"]:
+            self.print_resource_name("Parameter", parameter.name)
             click.echo("--> New Parameter")
 
-            if (not dry_run and confirm and
-                    click.confirm("--> Would you to create this SSM parameter?")) or \
-                    (not dry_run and confirm is False):
+            if (
+                not dry_run
+                and confirm
+                and click.confirm("--> Would you to create this SSM parameter?")
+            ) or (not dry_run and confirm is False):
                 parameter.create()
                 return True
         else:
-            if len(changes['ChangesList']) > 0:
-                self._deploy_parameter_changes(parameter, changes, dry_run, confirm)
+            if len(changes["ChangesList"]) > 0:
+                self._deploy_parameter_changes(
+                    parameter, changes, dry_run, confirm, show_diff
+                )
                 return True
 
-        return changes['Exists'] is False or len(changes['ChangesList']) > 0
+        return changes["Exists"] is False or len(changes["ChangesList"]) > 0
 
     def _deploy_parameter_changes(
         self,
         parameter: SSMParameterEntry,
         changes: Dict[str, Any],
         dry_run: bool,
-        confirm: bool
+        confirm: bool,
+        show_diff: bool,
     ) -> None:
         """
-            Update an existing parameter on the AWS environment
+        Update an existing parameter on the AWS environment
 
-            If the non replaceable attributes are found, recreate the resource instead of update
+        If the non replaceable attributes are found, recreate the resource instead of update
 
-            Args:
-                parameter (`SSMParameterEntry`): parameter entry object
-                changes (`Dict[str, Any]`): map of changes
-                dry_run: (`bool`): dry run flag, just calculate the changes, but not apply them.
-                confirm: (`bool`): CLI confirmation prompt for the changes.
+        Args:
+            parameter (`SSMParameterEntry`): parameter entry object
+            changes (`Dict[str, Any]`): map of changes
+            dry_run: (`bool`): dry run flag, just calculate the changes, but not apply them.
+            confirm: (`bool`): CLI confirmation prompt for the changes.
+            show_diff: (`bool`): show the diff of the changes
         """
-        self.print_resource_name('Parameter', parameter.name)
-        self.print_changes(changes)
+        self.print_resource_name("Parameter", parameter.name)
+        if confirm or show_diff:
+            self.print_changes(changes)
+        else:
+            click.echo(
+                "--> Parameter has changes, "
+                + "(use --show-diff to see the changes, not recommended when running in CI/CD)"
+            )
 
         if not dry_run:
             confirm_msg = "   --> Would you like to update this SSM parameter?"
@@ -218,44 +230,51 @@ class SSMProvider(BaseProvider):
                 param.delete()
                 param.create()
 
-            has_non_replaceable_changes = self.apply_non_replaceable_attrs(parameter, changes, non_replaceable_action)
+            has_non_replaceable_changes = self.apply_non_replaceable_attrs(
+                parameter, changes, non_replaceable_action
+            )
 
             if has_non_replaceable_changes is None:
                 return
 
-            if (has_non_replaceable_changes is False and confirm and click.confirm(confirm_msg)) or \
-                    (has_non_replaceable_changes is False and confirm is False):
+            if (
+                has_non_replaceable_changes is False
+                and confirm
+                and click.confirm(confirm_msg)
+            ) or (has_non_replaceable_changes is False and confirm is False):
                 parameter.update(changes)
 
     def get_sensible_entries(self) -> List[Dict[str, Any]]:
         """
-            Get sensible entries, all parameters typed `SecureString`
+        Get sensible entries, all parameters typed `SecureString`
 
-            Returns:
-                `List[Dict[str, Any]]`: list of sensible entries data
+        Returns:
+            `List[Dict[str, Any]]`: list of sensible entries data
         """
-        return list(filter(lambda p: p['type'] == 'SecureString', self._get_data_entries()))
+        return list(
+            filter(lambda p: p["type"] == "SecureString", self._get_data_entries())
+        )
 
     def _get_secrets_entries(self) -> List[Dict[str, Any]]:
         """
-            Get secrets config file entries
+        Get secrets config file entries
 
-            Returns:
-                `List[Dict[str, Any]]`: list of parameters data
+        Returns:
+            `List[Dict[str, Any]]`: list of parameters data
         """
-        if 'parameters' not in self.secrets_data:
-            self.secrets_data['parameters'] = []
+        if "parameters" not in self.secrets_data:
+            self.secrets_data["parameters"] = []
 
-        return self.secrets_data['parameters']
+        return self.secrets_data["parameters"]
 
     def _get_data_entries(self) -> List[Dict[str, Any]]:
         """
-            Get the parsed config YAML parameters
+        Get the parsed config YAML parameters
 
-            Returns:
-                `List[Dict[str, Any]]`: list of parameters
+        Returns:
+            `List[Dict[str, Any]]`: list of parameters
         """
-        if 'parameters' not in self.config_data:
-            self.config_data['parameters'] = []
+        if "parameters" not in self.config_data:
+            self.config_data["parameters"] = []
 
-        return self.config_data['parameters']
+        return self.config_data["parameters"]

--- a/tests/config/providers/secretsmanager/test_provider.py
+++ b/tests/config/providers/secretsmanager/test_provider.py
@@ -1,30 +1,36 @@
 from unittest.mock import patch
 
 import boto3
-from aws_secrets.config.config_reader import ConfigReader
-from aws_secrets.config.providers.secretsmanager.entry import SecretManagerEntry
-from aws_secrets.config.providers.secretsmanager.provider import SecretsManagerProvider
-from aws_secrets.miscellaneous import session
-from aws_secrets.representers.literal import Literal
 from botocore.stub import Stubber
 
-KEY_ARN = 'arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab'
-SECRET_ARN = 'arn:aws:secretsmanager:us-west-2:111122223333:secret:aes256-7g8H9i'
+from aws_secrets.config.config_reader import ConfigReader
+from aws_secrets.config.providers.secretsmanager.entry import \
+    SecretManagerEntry
+from aws_secrets.config.providers.secretsmanager.provider import \
+    SecretsManagerProvider
+from aws_secrets.miscellaneous import session
+from aws_secrets.representers.literal import Literal
+
+KEY_ARN = "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
+SECRET_ARN = "arn:aws:secretsmanager:us-west-2:111122223333:secret:aes256-7g8H9i"
 
 
 def test_secretsmanager_provider_instance(boto_fs):
     """
-        Should create the SecretsManager Provider object
+    Should create the SecretsManager Provider object
     """
 
-    config_file = 'config.yaml'
+    config_file = "config.yaml"
     session.aws_profile = None
-    session.aws_region = 'us-east-1'
+    session.aws_region = "us-east-1"
 
-    boto_fs.create_file(config_file, contents=f"""
+    boto_fs.create_file(
+        config_file,
+        contents=f"""
 kms:
     arn: {KEY_ARN}
-""")
+""",
+    )
 
     config = ConfigReader(config_file)
     provider = SecretsManagerProvider(config)
@@ -32,367 +38,372 @@ kms:
     assert len(provider.entries) == 0
 
 
-@patch('aws_secrets.miscellaneous.kms.decrypt')
-def test_secretsmanager_provider_decrypt(
-    mock_decrypt,
-    boto_fs
-):
+@patch("aws_secrets.miscellaneous.kms.decrypt")
+def test_secretsmanager_provider_decrypt(mock_decrypt, boto_fs):
     """
-        Should decrypt all the entries in the provider
+    Should decrypt all the entries in the provider
     """
 
-    mock_decrypt.return_value = b'PlainTextData'
+    mock_decrypt.return_value = b"PlainTextData"
 
-    config_file = 'config.yaml'
-    secrets_file = 'config.secrets.yaml'
+    config_file = "config.yaml"
+    secrets_file = "config.secrets.yaml"
     session.aws_profile = None
-    session.aws_region = 'us-east-1'
+    session.aws_region = "us-east-1"
 
-    boto_fs.create_file(config_file, contents=f"""
+    boto_fs.create_file(
+        config_file,
+        contents=f"""
 kms:
     arn: {KEY_ARN}
 secrets:
     - name: 'secret1'
-""")
+""",
+    )
 
-    boto_fs.create_file(secrets_file, contents="""
+    boto_fs.create_file(
+        secrets_file,
+        contents="""
 secrets:
     - name: 'secret1'
       value: 'SecretData'
-""")
+""",
+    )
 
     config = ConfigReader(config_file)
     provider = SecretsManagerProvider(config)
 
     provider.decrypt()
 
-    assert provider._get_data_entries() == [{
-        'name': 'secret1',
-        'value': 'PlainTextData'
-    }]
+    assert provider._get_data_entries() == [
+        {"name": "secret1", "value": "PlainTextData"}
+    ]
 
 
-@patch('aws_secrets.miscellaneous.kms.decrypt')
-def test_secretsmanager_provider_decrypt_multiline(
-    mock_decrypt,
-    boto_fs
-):
+@patch("aws_secrets.miscellaneous.kms.decrypt")
+def test_secretsmanager_provider_decrypt_multiline(mock_decrypt, boto_fs):
     """
-        Should decrypt all the entries in the provider
+    Should decrypt all the entries in the provider
 
-        Scenario:
-            - multiline value
+    Scenario:
+        - multiline value
     """
 
-    mock_decrypt.return_value = b'PlainTextData\nLine1\nLine2'
+    mock_decrypt.return_value = b"PlainTextData\nLine1\nLine2"
 
-    config_file = 'config.yaml'
-    secrets_file = 'config.secrets.yaml'
+    config_file = "config.yaml"
+    secrets_file = "config.secrets.yaml"
     session.aws_profile = None
-    session.aws_region = 'us-east-1'
+    session.aws_region = "us-east-1"
 
-    boto_fs.create_file(config_file, contents=f"""
+    boto_fs.create_file(
+        config_file,
+        contents=f"""
 kms:
     arn: {KEY_ARN}
 secrets:
     - name: 'secret1'
-""")
+""",
+    )
 
-    boto_fs.create_file(secrets_file, contents="""
+    boto_fs.create_file(
+        secrets_file,
+        contents="""
 secrets:
     - name: 'secret1'
       value: 'SecretData'
-""")
+""",
+    )
 
     config = ConfigReader(config_file)
     provider = SecretsManagerProvider(config)
 
     provider.decrypt()
 
-    assert provider._get_data_entries() == [{
-        'name': 'secret1',
-        'value': Literal('PlainTextData\nLine1\nLine2')
-    }]
+    assert provider._get_data_entries() == [
+        {"name": "secret1", "value": Literal("PlainTextData\nLine1\nLine2")}
+    ]
 
 
 def test_secretsmanager_provider_find_parameter(boto_fs):
     """
-        Should find the specific entry in the provider
+    Should find the specific entry in the provider
     """
 
-    config_file = 'config.yaml'
+    config_file = "config.yaml"
     session.aws_profile = None
-    session.aws_region = 'us-east-1'
+    session.aws_region = "us-east-1"
 
-    boto_fs.create_file(config_file, contents=f"""
+    boto_fs.create_file(
+        config_file,
+        contents=f"""
 kms:
     arn: {KEY_ARN}
 secrets:
     - name: 'secret1'
       value: 'ABC'
-""")
+""",
+    )
 
     config = ConfigReader(config_file)
     provider = SecretsManagerProvider(config)
 
-    assert isinstance(provider.find('secret1'), SecretManagerEntry)
+    assert isinstance(provider.find("secret1"), SecretManagerEntry)
 
 
 def test_secretsmanager_provider_not_find_parameter(boto_fs):
     """
-        Should not find the specific entry in the provider
+    Should not find the specific entry in the provider
     """
 
-    config_file = 'config.yaml'
+    config_file = "config.yaml"
     session.aws_profile = None
-    session.aws_region = 'us-east-1'
+    session.aws_region = "us-east-1"
 
-    boto_fs.create_file(config_file, contents=f"""
+    boto_fs.create_file(
+        config_file,
+        contents=f"""
 kms:
     arn: {KEY_ARN}
 secrets:
     - name: 'secret1'
       value: 'ABC'
-""")
+""",
+    )
 
     config = ConfigReader(config_file)
     provider = SecretsManagerProvider(config)
 
-    assert provider.find('secret2') is None
+    assert provider.find("secret2") is None
 
 
 def test_secretsmanager_provider_get_sensible_entries(boto_fs):
     """
-        Should not find the specific entry in the provider
+    Should not find the specific entry in the provider
     """
 
-    config_file = 'config.yaml'
-    secrets_file = 'config.secrets.yaml'
+    config_file = "config.yaml"
+    secrets_file = "config.secrets.yaml"
     session.aws_profile = None
-    session.aws_region = 'us-east-1'
+    session.aws_region = "us-east-1"
 
-    boto_fs.create_file(config_file, contents=f"""
+    boto_fs.create_file(
+        config_file,
+        contents=f"""
 kms:
     arn: {KEY_ARN}
 secrets:
     - name: 'secret1'
-""")
+""",
+    )
 
-    boto_fs.create_file(secrets_file, contents="""
+    boto_fs.create_file(
+        secrets_file,
+        contents="""
 secrets:
     - name: 'secret1'
       value: 'SecretData'
-""")
+""",
+    )
 
     config = ConfigReader(config_file)
     provider = SecretsManagerProvider(config)
 
-    assert provider.get_sensible_entries() == [{
-        'name': 'secret1'
-    }]
+    assert provider.get_sensible_entries() == [{"name": "secret1"}]
 
 
-@patch('aws_secrets.miscellaneous.kms.encrypt')
-def test_secretsmanager_provider_encrypt(
-    mock_encrypt,
-    boto_fs
-):
+@patch("aws_secrets.miscellaneous.kms.encrypt")
+def test_secretsmanager_provider_encrypt(mock_encrypt, boto_fs):
     """
-        Should encrypt all the entries in the provider
+    Should encrypt all the entries in the provider
     """
 
-    mock_encrypt.return_value = b'SecretData'
+    mock_encrypt.return_value = b"SecretData"
 
-    config_file = 'config.yaml'
+    config_file = "config.yaml"
     session.aws_profile = None
-    session.aws_region = 'us-east-1'
+    session.aws_region = "us-east-1"
 
-    boto_fs.create_file(config_file, contents=f"""
+    boto_fs.create_file(
+        config_file,
+        contents=f"""
 kms:
     arn: {KEY_ARN}
 secrets:
     - name: 'secret1'
       value: 'PlainTextData'
-""")
+""",
+    )
 
     config = ConfigReader(config_file)
     provider = SecretsManagerProvider(config)
 
-    assert provider.encrypt() == [{
-        'name': 'secret1',
-        'value': 'SecretData'
-    }]
+    assert provider.encrypt() == [{"name": "secret1", "value": "SecretData"}]
 
 
-def test_secretsmanager_provider_add(
-    boto_fs
-):
+def test_secretsmanager_provider_add(boto_fs):
     """
-        Should add a new entry to the provider
+    Should add a new entry to the provider
     """
 
-    config_file = 'config.yaml'
-    secrets_file = 'config.secrets.yaml'
+    config_file = "config.yaml"
+    secrets_file = "config.secrets.yaml"
     session.aws_profile = None
-    session.aws_region = 'us-east-1'
+    session.aws_region = "us-east-1"
 
-    boto_fs.create_file(config_file, contents=f"""
+    boto_fs.create_file(
+        config_file,
+        contents=f"""
 kms:
     arn: {KEY_ARN}
 secrets:
     - name: 'secret1'
-""")
+""",
+    )
 
-    boto_fs.create_file(secrets_file, contents="""
+    boto_fs.create_file(
+        secrets_file,
+        contents="""
 secrets:
     - name: 'secret1'
       value: 'SecretData'
-""")
+""",
+    )
 
     config = ConfigReader(config_file)
     provider = SecretsManagerProvider(config)
 
-    assert isinstance(provider.add({
-        'name': 'secret2',
-        'value': 'PlainTextData2'
-    }), SecretManagerEntry)
+    assert isinstance(
+        provider.add({"name": "secret2", "value": "PlainTextData2"}), SecretManagerEntry
+    )
 
-    assert provider._get_data_entries() == [{
-        'name': 'secret1'
-    }, {
-        'name': 'secret2',
-        'value': 'PlainTextData2'
-    }]
+    assert provider._get_data_entries() == [
+        {"name": "secret1"},
+        {"name": "secret2", "value": "PlainTextData2"},
+    ]
 
 
-def test_secretsmanager_provider_update(
-    boto_fs
-):
+def test_secretsmanager_provider_update(boto_fs):
     """
-        Should update an existing entry
+    Should update an existing entry
     """
 
-    config_file = 'config.yaml'
-    secrets_file = 'config.secrets.yaml'
+    config_file = "config.yaml"
+    secrets_file = "config.secrets.yaml"
     session.aws_profile = None
-    session.aws_region = 'us-east-1'
+    session.aws_region = "us-east-1"
 
-    boto_fs.create_file(config_file, contents=f"""
+    boto_fs.create_file(
+        config_file,
+        contents=f"""
 kms:
     arn: {KEY_ARN}
 secrets:
     - name: 'secret1'
     - name: 'secret2'
-""")
+""",
+    )
 
-    boto_fs.create_file(secrets_file, contents="""
+    boto_fs.create_file(
+        secrets_file,
+        contents="""
 secrets:
     - name: 'secret1'
       value: 'SecretData'
     - name: 'secret2'
       value: 'SecretData'
-""")
+""",
+    )
 
     config = ConfigReader(config_file)
     provider = SecretsManagerProvider(config)
 
-    provider.update({
-        'name': 'secret1',
-        'value': 'PlainTextData',
-        'description': 'Desc'
-    })
+    provider.update(
+        {"name": "secret1", "value": "PlainTextData", "description": "Desc"}
+    )
 
-    assert provider._get_data_entries() == [{
-        'name': 'secret1',
-        'value': 'PlainTextData',
-        'description': 'Desc'
-    }, {
-        'name': 'secret2'
-    }]
+    assert provider._get_data_entries() == [
+        {"name": "secret1", "value": "PlainTextData", "description": "Desc"},
+        {"name": "secret2"},
+    ]
 
 
-@patch('aws_secrets.miscellaneous.kms.decrypt')
-def test_secretsmanager_provider_deploy_dry_run(
-    mock_decrypt,
-    boto_fs,
-    capsys
-):
+@patch("aws_secrets.miscellaneous.kms.decrypt")
+def test_secretsmanager_provider_deploy_dry_run(mock_decrypt, boto_fs, capsys):
     """
-        Should deploy the AWS Secrets Manager changes
+    Should deploy the AWS Secrets Manager changes
     """
 
-    mock_decrypt.return_value = b'PlainTextData'
-    client = boto3.client('secretsmanager')
+    mock_decrypt.return_value = b"PlainTextData"
+    client = boto3.client("secretsmanager")
 
-    with patch.object(boto3.Session, 'client') as mock_client:
+    with patch.object(boto3.Session, "client") as mock_client:
         with Stubber(client) as stubber:
             mock_client.return_value = client
-            stubber.add_response('list_secrets', {
-                'SecretList': []
-            }, {
-                'Filters': [
-                    {
-                        'Key': 'name',
-                        'Values': ['secret1']
-                    }
-                ]
-            })
-            stubber.add_response('list_secrets', {
-                'SecretList': [{
-                    'ARN': SECRET_ARN,
-                    'Name': 'secret2',
-                    'Description': '',
-                    'Tags': []
-                }]
-            }, {
-                'Filters': [
-                    {
-                        'Key': 'name',
-                        'Values': ['secret2']
-                    }
-                ]
-            })
-            stubber.add_response('get_secret_value', {
-                'SecretString': 'PlainTextData'
-            }, {
-                'SecretId': 'secret2'
-            })
-            stubber.add_response('list_secrets', {
-                'SecretList': [{
-                    'ARN': SECRET_ARN,
-                    'Name': 'secret3',
-                    'Description': '',
-                    'Tags': []
-                }]
-            }, {
-                'Filters': [
-                    {
-                        'Key': 'name',
-                        'Values': ['secret3']
-                    }
-                ]
-            })
-            stubber.add_response('get_secret_value', {
-                'SecretString': 'PlainTextData2'
-            }, {
-                'SecretId': 'secret3'
-            })
+            stubber.add_response(
+                "list_secrets",
+                {"SecretList": []},
+                {"Filters": [{"Key": "name", "Values": ["secret1"]}]},
+            )
+            stubber.add_response(
+                "list_secrets",
+                {
+                    "SecretList": [
+                        {
+                            "ARN": SECRET_ARN,
+                            "Name": "secret2",
+                            "Description": "",
+                            "Tags": [],
+                        }
+                    ]
+                },
+                {"Filters": [{"Key": "name", "Values": ["secret2"]}]},
+            )
+            stubber.add_response(
+                "get_secret_value",
+                {"SecretString": "PlainTextData"},
+                {"SecretId": "secret2"},
+            )
+            stubber.add_response(
+                "list_secrets",
+                {
+                    "SecretList": [
+                        {
+                            "ARN": SECRET_ARN,
+                            "Name": "secret3",
+                            "Description": "",
+                            "Tags": [],
+                        }
+                    ]
+                },
+                {"Filters": [{"Key": "name", "Values": ["secret3"]}]},
+            )
+            stubber.add_response(
+                "get_secret_value",
+                {"SecretString": "PlainTextData2"},
+                {"SecretId": "secret3"},
+            )
 
-            config_file = 'config.yaml'
-            secrets_file = 'config.secrets.yaml'
+            config_file = "config.yaml"
+            secrets_file = "config.secrets.yaml"
             session.aws_profile = None
-            session.aws_region = 'us-east-1'
+            session.aws_region = "us-east-1"
 
-            boto_fs.create_file(config_file, contents=f"""
+            boto_fs.create_file(
+                config_file,
+                contents=f"""
 kms:
     arn: {KEY_ARN}
 secrets:
     - name: 'secret1'
     - name: 'secret2'
     - name: 'secret3'
-        """)
+        """,
+            )
 
-            boto_fs.create_file(secrets_file, contents="""
+            boto_fs.create_file(
+                secrets_file,
+                contents="""
 secrets:
     - name: 'secret1'
       value: 'SecretData'
@@ -400,105 +411,205 @@ secrets:
       value: 'SecretData'
     - name: 'secret3'
       value: 'SecretData'
-        """)
+        """,
+            )
 
             config = ConfigReader(config_file)
             provider = SecretsManagerProvider(config)
 
-            provider.deploy(None, True, False)
+            provider.deploy(None, True, False, True)
 
             captured = capsys.readouterr()
 
             assert "Secret: [secret1]\n--> New Secret\n" in captured.out
-            assert "Secret: [secret3]\n--> Changes:\n   -->" + \
-                " Value:\n          Old Value: PlainTextData2\n          New Value: PlainTextData\n" in captured.out
+            assert (
+                "Secret: [secret3]\n--> Changes:\n   -->"
+                + " Value:\n          Old Value: PlainTextData2\n          New Value: PlainTextData\n"
+                in captured.out
+            )
 
 
-@patch('aws_secrets.miscellaneous.kms.decrypt')
-@patch('click.confirm')
+@patch("aws_secrets.miscellaneous.kms.decrypt")
+def test_secretsmanager_provider_deploy_dry_run_no_diff(mock_decrypt, boto_fs, capsys):
+    """
+    Should deploy the AWS Secrets Manager changes
+    """
+
+    mock_decrypt.return_value = b"PlainTextData"
+    client = boto3.client("secretsmanager")
+
+    with patch.object(boto3.Session, "client") as mock_client:
+        with Stubber(client) as stubber:
+            mock_client.return_value = client
+            stubber.add_response(
+                "list_secrets",
+                {"SecretList": []},
+                {"Filters": [{"Key": "name", "Values": ["secret1"]}]},
+            )
+            stubber.add_response(
+                "list_secrets",
+                {
+                    "SecretList": [
+                        {
+                            "ARN": SECRET_ARN,
+                            "Name": "secret2",
+                            "Description": "",
+                            "Tags": [],
+                        }
+                    ]
+                },
+                {"Filters": [{"Key": "name", "Values": ["secret2"]}]},
+            )
+            stubber.add_response(
+                "get_secret_value",
+                {"SecretString": "PlainTextData"},
+                {"SecretId": "secret2"},
+            )
+            stubber.add_response(
+                "list_secrets",
+                {
+                    "SecretList": [
+                        {
+                            "ARN": SECRET_ARN,
+                            "Name": "secret3",
+                            "Description": "",
+                            "Tags": [],
+                        }
+                    ]
+                },
+                {"Filters": [{"Key": "name", "Values": ["secret3"]}]},
+            )
+            stubber.add_response(
+                "get_secret_value",
+                {"SecretString": "PlainTextData2"},
+                {"SecretId": "secret3"},
+            )
+
+            config_file = "config.yaml"
+            secrets_file = "config.secrets.yaml"
+            session.aws_profile = None
+            session.aws_region = "us-east-1"
+
+            boto_fs.create_file(
+                config_file,
+                contents=f"""
+kms:
+    arn: {KEY_ARN}
+secrets:
+    - name: 'secret1'
+    - name: 'secret2'
+    - name: 'secret3'
+        """,
+            )
+
+            boto_fs.create_file(
+                secrets_file,
+                contents="""
+secrets:
+    - name: 'secret1'
+      value: 'SecretData'
+    - name: 'secret2'
+      value: 'SecretData'
+    - name: 'secret3'
+      value: 'SecretData'
+        """,
+            )
+
+            config = ConfigReader(config_file)
+            provider = SecretsManagerProvider(config)
+
+            provider.deploy(None, True, False, False)
+
+            captured = capsys.readouterr()
+
+            assert "Secret: [secret1]\n--> New Secret\n" in captured.out
+            assert (
+                "[secret3]\n--> Secret has changes, "
+                + "(use --show-diff to see the changes, not recommended when running in CI/CD)\n"
+                in captured.out
+            )
+
+
+@patch("aws_secrets.miscellaneous.kms.decrypt")
+@patch("click.confirm")
 def test_secretsmanager_provider_deploy_confirm_no(
-    mock_confirm,
-    mock_decrypt,
-    boto_fs,
-    capsys
+    mock_confirm, mock_decrypt, boto_fs, capsys
 ):
     """
-        Should deploy the AWS Secrets Manager changes
+    Should deploy the AWS Secrets Manager changes
     """
 
-    mock_decrypt.return_value = b'PlainTextData'
+    mock_decrypt.return_value = b"PlainTextData"
     mock_confirm.return_value = False
-    client = boto3.client('secretsmanager')
+    client = boto3.client("secretsmanager")
 
-    with patch.object(boto3.Session, 'client') as mock_client:
+    with patch.object(boto3.Session, "client") as mock_client:
         with Stubber(client) as stubber:
             mock_client.return_value = client
-            stubber.add_response('list_secrets', {
-                'SecretList': []
-            }, {
-                'Filters': [
-                    {
-                        'Key': 'name',
-                        'Values': ['secret1']
-                    }
-                ]
-            })
-            stubber.add_response('list_secrets', {
-                'SecretList': [{
-                    'ARN': SECRET_ARN,
-                    'Name': 'secret2',
-                    'Description': '',
-                    'Tags': []
-                }]
-            }, {
-                'Filters': [
-                    {
-                        'Key': 'name',
-                        'Values': ['secret2']
-                    }
-                ]
-            })
-            stubber.add_response('get_secret_value', {
-                'SecretString': 'PlainTextData'
-            }, {
-                'SecretId': 'secret2'
-            })
-            stubber.add_response('list_secrets', {
-                'SecretList': [{
-                    'ARN': SECRET_ARN,
-                    'Name': 'secret3',
-                    'Description': '',
-                    'Tags': []
-                }]
-            }, {
-                'Filters': [
-                    {
-                        'Key': 'name',
-                        'Values': ['secret3']
-                    }
-                ]
-            })
-            stubber.add_response('get_secret_value', {
-                'SecretString': 'PlainTextData2'
-            }, {
-                'SecretId': 'secret3'
-            })
+            stubber.add_response(
+                "list_secrets",
+                {"SecretList": []},
+                {"Filters": [{"Key": "name", "Values": ["secret1"]}]},
+            )
+            stubber.add_response(
+                "list_secrets",
+                {
+                    "SecretList": [
+                        {
+                            "ARN": SECRET_ARN,
+                            "Name": "secret2",
+                            "Description": "",
+                            "Tags": [],
+                        }
+                    ]
+                },
+                {"Filters": [{"Key": "name", "Values": ["secret2"]}]},
+            )
+            stubber.add_response(
+                "get_secret_value",
+                {"SecretString": "PlainTextData"},
+                {"SecretId": "secret2"},
+            )
+            stubber.add_response(
+                "list_secrets",
+                {
+                    "SecretList": [
+                        {
+                            "ARN": SECRET_ARN,
+                            "Name": "secret3",
+                            "Description": "",
+                            "Tags": [],
+                        }
+                    ]
+                },
+                {"Filters": [{"Key": "name", "Values": ["secret3"]}]},
+            )
+            stubber.add_response(
+                "get_secret_value",
+                {"SecretString": "PlainTextData2"},
+                {"SecretId": "secret3"},
+            )
 
-            config_file = 'config.yaml'
-            secrets_file = 'config.secrets.yaml'
+            config_file = "config.yaml"
+            secrets_file = "config.secrets.yaml"
             session.aws_profile = None
-            session.aws_region = 'us-east-1'
+            session.aws_region = "us-east-1"
 
-            boto_fs.create_file(config_file, contents=f"""
+            boto_fs.create_file(
+                config_file,
+                contents=f"""
 kms:
     arn: {KEY_ARN}
 secrets:
     - name: 'secret1'
     - name: 'secret2'
     - name: 'secret3'
-        """)
+        """,
+            )
 
-            boto_fs.create_file(secrets_file, contents="""
+            boto_fs.create_file(
+                secrets_file,
+                contents="""
 secrets:
     - name: 'secret1'
       value: 'SecretData'
@@ -506,117 +617,122 @@ secrets:
       value: 'SecretData'
     - name: 'secret3'
       value: 'SecretData'
-        """)
+        """,
+            )
 
             config = ConfigReader(config_file)
             provider = SecretsManagerProvider(config)
 
-            provider.deploy(None, False, True)
+            provider.deploy(None, False, True, True)
 
             captured = capsys.readouterr()
 
             assert "Secret: [secret1]\n--> New Secret\n" in captured.out
-            assert "Secret: [secret3]\n--> Changes:\n   -->" + \
-                " Value:\n          Old Value: PlainTextData2\n          New Value: PlainTextData\n" in captured.out
+            assert (
+                "Secret: [secret3]\n--> Changes:\n   -->"
+                + " Value:\n          Old Value: PlainTextData2\n          New Value: PlainTextData\n"
+                in captured.out
+            )
 
 
-@patch('aws_secrets.miscellaneous.kms.decrypt')
-def test_secretsmanager_provider_deploy(
-    mock_decrypt,
-    boto_fs,
-    capsys
-):
+@patch("aws_secrets.miscellaneous.kms.decrypt")
+def test_secretsmanager_provider_deploy(mock_decrypt, boto_fs, capsys):
     """
-        Should deploy the AWS Secrets Manager changes
+    Should deploy the AWS Secrets Manager changes
     """
 
-    mock_decrypt.return_value = b'PlainTextData'
-    client = boto3.client('secretsmanager')
+    mock_decrypt.return_value = b"PlainTextData"
+    client = boto3.client("secretsmanager")
 
-    with patch.object(boto3.Session, 'client') as mock_client:
+    with patch.object(boto3.Session, "client") as mock_client:
         with Stubber(client) as stubber:
             mock_client.return_value = client
-            stubber.add_response('list_secrets', {
-                'SecretList': []
-            }, {
-                'Filters': [
-                    {
-                        'Key': 'name',
-                        'Values': ['secret1']
-                    }
-                ]
-            })
-            stubber.add_response('create_secret', {}, {
-                'Name': 'secret1',
-                'Description': '',
-                'SecretString': 'PlainTextData',
-                'Tags': []
-            })
-            stubber.add_response('list_secrets', {
-                'SecretList': [{
-                    'ARN': SECRET_ARN,
-                    'Name': 'secret2',
-                    'Description': '',
-                    'Tags': []
-                }]
-            }, {
-                'Filters': [
-                    {
-                        'Key': 'name',
-                        'Values': ['secret2']
-                    }
-                ]
-            })
-            stubber.add_response('get_secret_value', {
-                'SecretString': 'PlainTextData'
-            }, {
-                'SecretId': 'secret2'
-            })
-            stubber.add_response('list_secrets', {
-                'SecretList': [{
-                    'ARN': SECRET_ARN,
-                    'Name': 'secret3',
-                    'Description': '',
-                    'Tags': []
-                }]
-            }, {
-                'Filters': [
-                    {
-                        'Key': 'name',
-                        'Values': ['secret3']
-                    }
-                ]
-            })
-            stubber.add_response('get_secret_value', {
-                'SecretString': 'PlainTextData2'
-            }, {
-                'SecretId': 'secret3'
-            })
-            stubber.add_response('update_secret', {}, {
-                'SecretId': 'secret3',
-                'Description': '',
-                'SecretString': 'PlainTextData'
-            })
-            stubber.add_response('untag_resource', {}, {
-                'SecretId': 'secret3',
-                'TagKeys': []
-            })
+            stubber.add_response(
+                "list_secrets",
+                {"SecretList": []},
+                {"Filters": [{"Key": "name", "Values": ["secret1"]}]},
+            )
+            stubber.add_response(
+                "create_secret",
+                {},
+                {
+                    "Name": "secret1",
+                    "Description": "",
+                    "SecretString": "PlainTextData",
+                    "Tags": [],
+                },
+            )
+            stubber.add_response(
+                "list_secrets",
+                {
+                    "SecretList": [
+                        {
+                            "ARN": SECRET_ARN,
+                            "Name": "secret2",
+                            "Description": "",
+                            "Tags": [],
+                        }
+                    ]
+                },
+                {"Filters": [{"Key": "name", "Values": ["secret2"]}]},
+            )
+            stubber.add_response(
+                "get_secret_value",
+                {"SecretString": "PlainTextData"},
+                {"SecretId": "secret2"},
+            )
+            stubber.add_response(
+                "list_secrets",
+                {
+                    "SecretList": [
+                        {
+                            "ARN": SECRET_ARN,
+                            "Name": "secret3",
+                            "Description": "",
+                            "Tags": [],
+                        }
+                    ]
+                },
+                {"Filters": [{"Key": "name", "Values": ["secret3"]}]},
+            )
+            stubber.add_response(
+                "get_secret_value",
+                {"SecretString": "PlainTextData2"},
+                {"SecretId": "secret3"},
+            )
+            stubber.add_response(
+                "update_secret",
+                {},
+                {
+                    "SecretId": "secret3",
+                    "Description": "",
+                    "SecretString": "PlainTextData",
+                },
+            )
+            stubber.add_response(
+                "untag_resource", {}, {"SecretId": "secret3", "TagKeys": []}
+            )
 
-            config_file = 'config.yaml'
-            secrets_file = 'config.secrets.yaml'
+            config_file = "config.yaml"
+            secrets_file = "config.secrets.yaml"
             session.aws_profile = None
-            session.aws_region = 'us-east-1'
+            session.aws_region = "us-east-1"
 
-            boto_fs.create_file(config_file, contents=f"""
+            boto_fs.create_file(
+                config_file,
+                contents=f"""
 kms:
     arn: {KEY_ARN}
 secrets:
     - name: 'secret1'
     - name: 'secret2'
     - name: 'secret3'
-        """)
+        """,
+            )
 
-            boto_fs.create_file(secrets_file, contents="""
+            boto_fs.create_file(
+                secrets_file,
+                contents="""
 secrets:
     - name: 'secret1'
       value: 'SecretData'
@@ -624,82 +740,88 @@ secrets:
       value: 'SecretData'
     - name: 'secret3'
       value: 'SecretData'
-        """)
+        """,
+            )
 
             config = ConfigReader(config_file)
             provider = SecretsManagerProvider(config)
 
-            provider.deploy(None, False, False)
+            provider.deploy(None, False, False, True)
 
             captured = capsys.readouterr()
 
             assert "Secret: [secret1]\n--> New Secret\n" in captured.out
-            assert "Secret: [secret3]\n--> Changes:\n   -->" + \
-                " Value:\n          Old Value: PlainTextData2\n          New Value: PlainTextData\n" in captured.out
+            assert (
+                "Secret: [secret3]\n--> Changes:\n   -->"
+                + " Value:\n          Old Value: PlainTextData2\n          New Value: PlainTextData\n"
+                in captured.out
+            )
 
 
-@patch('aws_secrets.miscellaneous.kms.decrypt')
-@patch('click.confirm')
+@patch("aws_secrets.miscellaneous.kms.decrypt")
+@patch("click.confirm")
 def test_secretsmanager_provider_deploy_no_changes(
-    mock_confirm,
-    mock_decrypt,
-    boto_fs,
-    capsys
+    mock_confirm, mock_decrypt, boto_fs, capsys
 ):
     """
-        Should deploy the AWS Secrets Manager changes
+    Should deploy the AWS Secrets Manager changes
     """
 
-    mock_decrypt.return_value = b'PlainTextData'
+    mock_decrypt.return_value = b"PlainTextData"
     mock_confirm.return_value = False
-    client = boto3.client('secretsmanager')
+    client = boto3.client("secretsmanager")
 
-    with patch.object(boto3.Session, 'client') as mock_client:
+    with patch.object(boto3.Session, "client") as mock_client:
         with Stubber(client) as stubber:
             mock_client.return_value = client
-            stubber.add_response('list_secrets', {
-                'SecretList': [{
-                    'ARN': SECRET_ARN,
-                    'Name': 'secret2',
-                    'Description': '',
-                    'Tags': []
-                }]
-            }, {
-                'Filters': [
-                    {
-                        'Key': 'name',
-                        'Values': ['secret2']
-                    }
-                ]
-            })
-            stubber.add_response('get_secret_value', {
-                'SecretString': 'PlainTextData'
-            }, {
-                'SecretId': 'secret2'
-            })
+            stubber.add_response(
+                "list_secrets",
+                {
+                    "SecretList": [
+                        {
+                            "ARN": SECRET_ARN,
+                            "Name": "secret2",
+                            "Description": "",
+                            "Tags": [],
+                        }
+                    ]
+                },
+                {"Filters": [{"Key": "name", "Values": ["secret2"]}]},
+            )
+            stubber.add_response(
+                "get_secret_value",
+                {"SecretString": "PlainTextData"},
+                {"SecretId": "secret2"},
+            )
 
-            config_file = 'config.yaml'
-            secrets_file = 'config.secrets.yaml'
+            config_file = "config.yaml"
+            secrets_file = "config.secrets.yaml"
             session.aws_profile = None
-            session.aws_region = 'us-east-1'
+            session.aws_region = "us-east-1"
 
-            boto_fs.create_file(config_file, contents=f"""
+            boto_fs.create_file(
+                config_file,
+                contents=f"""
 kms:
     arn: {KEY_ARN}
 secrets:
     - name: 'secret2'
-        """)
+        """,
+            )
 
-            boto_fs.create_file(secrets_file, contents="""
+            boto_fs.create_file(
+                secrets_file,
+                contents="""
 secrets:
     - name: 'secret2'
       value: 'SecretData'
-        """)
+        """,
+            )
 
             config = ConfigReader(config_file)
             provider = SecretsManagerProvider(config)
 
-            provider.deploy(None, False, True)
+            provider.deploy(None, False, True, True)
 
             captured = capsys.readouterr()
 

--- a/tests/config/providers/ssm/test_provider.py
+++ b/tests/config/providers/ssm/test_provider.py
@@ -1,29 +1,33 @@
 from unittest.mock import patch
 
 import boto3
+from botocore.stub import Stubber
+
 from aws_secrets.config.config_reader import ConfigReader
 from aws_secrets.config.providers.ssm.entry import SSMParameterEntry
 from aws_secrets.config.providers.ssm.provider import SSMProvider
 from aws_secrets.miscellaneous import session
 from aws_secrets.representers.literal import Literal
-from botocore.stub import Stubber
 
-KEY_ARN = 'arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab'
+KEY_ARN = "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
 
 
 def test_ssm_provider_instance(boto_fs):
     """
-        Should create the SSM Provider object
+    Should create the SSM Provider object
     """
 
-    config_file = 'config.yaml'
+    config_file = "config.yaml"
     session.aws_profile = None
-    session.aws_region = 'us-east-1'
+    session.aws_region = "us-east-1"
 
-    boto_fs.create_file(config_file, contents=f"""
+    boto_fs.create_file(
+        config_file,
+        contents=f"""
 kms:
     arn: {KEY_ARN}
-""")
+""",
+    )
 
     config = ConfigReader(config_file)
 
@@ -34,186 +38,201 @@ kms:
 
 def test_ssm_provider_decrypt_parameter_not_secure_string(boto_fs):
     """
-        Should decrypt all the entries in the provider
+    Should decrypt all the entries in the provider
 
-        Scenario:
-            - SSM parameter is not secure string
+    Scenario:
+        - SSM parameter is not secure string
     """
 
-    config_file = 'config.yaml'
+    config_file = "config.yaml"
     session.aws_profile = None
-    session.aws_region = 'us-east-1'
+    session.aws_region = "us-east-1"
 
-    boto_fs.create_file(config_file, contents=f"""
+    boto_fs.create_file(
+        config_file,
+        contents=f"""
 kms:
     arn: {KEY_ARN}
 parameters:
     - name: 'ssm-param'
       type: 'String'
       value: 'ABC'
-""")
+""",
+    )
 
     config = ConfigReader(config_file)
     provider = SSMProvider(config)
 
     provider.decrypt()
 
-    assert provider._get_data_entries() == [{
-        'name': 'ssm-param',
-        'type': 'String',
-        'value': 'ABC'
-    }]
+    assert provider._get_data_entries() == [
+        {"name": "ssm-param", "type": "String", "value": "ABC"}
+    ]
 
 
-@patch('aws_secrets.miscellaneous.kms.decrypt')
-def test_ssm_provider_decrypt_parameter_secure_string(
-    mock_decrypt,
-    boto_fs
-):
+@patch("aws_secrets.miscellaneous.kms.decrypt")
+def test_ssm_provider_decrypt_parameter_secure_string(mock_decrypt, boto_fs):
     """
-        Should decrypt all the entries in the provider
+    Should decrypt all the entries in the provider
 
-        Scenario:
-            - SSM parameter is secure string
+    Scenario:
+        - SSM parameter is secure string
     """
 
-    mock_decrypt.return_value = b'PlainTextData'
+    mock_decrypt.return_value = b"PlainTextData"
 
-    config_file = 'config.yaml'
-    secrets_file = 'config.secrets.yaml'
+    config_file = "config.yaml"
+    secrets_file = "config.secrets.yaml"
     session.aws_profile = None
-    session.aws_region = 'us-east-1'
+    session.aws_region = "us-east-1"
 
-    boto_fs.create_file(config_file, contents=f"""
+    boto_fs.create_file(
+        config_file,
+        contents=f"""
 kms:
     arn: {KEY_ARN}
 parameters:
     - name: 'ssm-param'
       type: 'SecureString'
-""")
+""",
+    )
 
-    boto_fs.create_file(secrets_file, contents="""
+    boto_fs.create_file(
+        secrets_file,
+        contents="""
 parameters:
     - name: 'ssm-param'
       value: 'SecretData'
-""")
+""",
+    )
 
     config = ConfigReader(config_file)
     provider = SSMProvider(config)
 
     provider.decrypt()
 
-    assert provider._get_data_entries() == [{
-        'name': 'ssm-param',
-        'type': 'SecureString',
-        'value': 'PlainTextData'
-    }]
+    assert provider._get_data_entries() == [
+        {"name": "ssm-param", "type": "SecureString", "value": "PlainTextData"}
+    ]
 
 
-@patch('aws_secrets.miscellaneous.kms.decrypt')
-def test_ssm_provider_decrypt_parameter_secure_string_multiline(
-    mock_decrypt,
-    boto_fs
-):
+@patch("aws_secrets.miscellaneous.kms.decrypt")
+def test_ssm_provider_decrypt_parameter_secure_string_multiline(mock_decrypt, boto_fs):
     """
-        Should decrypt all the entries in the provider
+    Should decrypt all the entries in the provider
 
-        Scenario:
-            - SSM parameter is not secure string with multiline value
+    Scenario:
+        - SSM parameter is not secure string with multiline value
     """
 
-    mock_decrypt.return_value = b'PlainTextData\nLine1\nLine2'
+    mock_decrypt.return_value = b"PlainTextData\nLine1\nLine2"
 
-    config_file = 'config.yaml'
-    secrets_file = 'config.secrets.yaml'
+    config_file = "config.yaml"
+    secrets_file = "config.secrets.yaml"
     session.aws_profile = None
-    session.aws_region = 'us-east-1'
+    session.aws_region = "us-east-1"
 
-    boto_fs.create_file(config_file, contents=f"""
+    boto_fs.create_file(
+        config_file,
+        contents=f"""
 kms:
     arn: {KEY_ARN}
 parameters:
     - name: 'ssm-param'
       type: 'SecureString'
-""")
+""",
+    )
 
-    boto_fs.create_file(secrets_file, contents="""
+    boto_fs.create_file(
+        secrets_file,
+        contents="""
 parameters:
     - name: 'ssm-param'
       value: 'SecretData'
-""")
+""",
+    )
 
     config = ConfigReader(config_file)
     provider = SSMProvider(config)
 
     provider.decrypt()
 
-    assert provider._get_data_entries() == [{
-        'name': 'ssm-param',
-        'type': 'SecureString',
-        'value': Literal('PlainTextData\nLine1\nLine2')
-    }]
+    assert provider._get_data_entries() == [
+        {
+            "name": "ssm-param",
+            "type": "SecureString",
+            "value": Literal("PlainTextData\nLine1\nLine2"),
+        }
+    ]
 
 
 def test_ssm_provider_find_parameter(boto_fs):
     """
-        Should find the specific entry in the provider
+    Should find the specific entry in the provider
     """
 
-    config_file = 'config.yaml'
+    config_file = "config.yaml"
     session.aws_profile = None
-    session.aws_region = 'us-east-1'
+    session.aws_region = "us-east-1"
 
-    boto_fs.create_file(config_file, contents=f"""
+    boto_fs.create_file(
+        config_file,
+        contents=f"""
 kms:
     arn: {KEY_ARN}
 parameters:
     - name: 'ssm-param'
       type: 'String'
       value: 'ABC'
-""")
+""",
+    )
 
     config = ConfigReader(config_file)
     provider = SSMProvider(config)
 
-    assert isinstance(provider.find('ssm-param'), SSMParameterEntry)
+    assert isinstance(provider.find("ssm-param"), SSMParameterEntry)
 
 
 def test_ssm_provider_not_find_parameter(boto_fs):
     """
-        Should not find the specific entry in the provider
+    Should not find the specific entry in the provider
     """
 
-    config_file = 'config.yaml'
+    config_file = "config.yaml"
     session.aws_profile = None
-    session.aws_region = 'us-east-1'
+    session.aws_region = "us-east-1"
 
-    boto_fs.create_file(config_file, contents=f"""
+    boto_fs.create_file(
+        config_file,
+        contents=f"""
 kms:
     arn: {KEY_ARN}
 parameters:
     - name: 'ssm-param'
       type: 'String'
       value: 'ABC'
-""")
+""",
+    )
 
     config = ConfigReader(config_file)
     provider = SSMProvider(config)
 
-    assert provider.find('ssm-paramm') is None
+    assert provider.find("ssm-paramm") is None
 
 
 def test_ssm_provider_get_sensible_entries(boto_fs):
     """
-        Should not find the specific entry in the provider
+    Should not find the specific entry in the provider
     """
 
-    config_file = 'config.yaml'
-    secrets_file = 'config.secrets.yaml'
+    config_file = "config.yaml"
+    secrets_file = "config.secrets.yaml"
     session.aws_profile = None
-    session.aws_region = 'us-east-1'
+    session.aws_region = "us-east-1"
 
-    boto_fs.create_file(config_file, contents=f"""
+    boto_fs.create_file(
+        config_file,
+        contents=f"""
 kms:
     arn: {KEY_ARN}
 parameters:
@@ -222,42 +241,44 @@ parameters:
       value: 'ABC'
     - name: 'ssm-param1'
       type: 'SecureString'
-""")
+""",
+    )
 
-    boto_fs.create_file(secrets_file, contents="""
+    boto_fs.create_file(
+        secrets_file,
+        contents="""
 parameters:
     - name: 'ssm-param1'
       value: 'SecretData'
-""")
+""",
+    )
 
     config = ConfigReader(config_file)
     provider = SSMProvider(config)
 
-    assert provider.get_sensible_entries() == [{
-        'name': 'ssm-param1',
-        'type': 'SecureString'
-    }]
+    assert provider.get_sensible_entries() == [
+        {"name": "ssm-param1", "type": "SecureString"}
+    ]
 
 
-@patch('aws_secrets.miscellaneous.kms.encrypt')
-def test_ssm_provider_encrypt_parameter_secure_string(
-    mock_encrypt,
-    boto_fs
-):
+@patch("aws_secrets.miscellaneous.kms.encrypt")
+def test_ssm_provider_encrypt_parameter_secure_string(mock_encrypt, boto_fs):
     """
-        Should encrypt all the entries in the provider
+    Should encrypt all the entries in the provider
 
-        Scenario:
-            - SSM parameter is secure string
+    Scenario:
+        - SSM parameter is secure string
     """
 
-    mock_encrypt.return_value = b'SecretData'
+    mock_encrypt.return_value = b"SecretData"
 
-    config_file = 'config.yaml'
+    config_file = "config.yaml"
     session.aws_profile = None
-    session.aws_region = 'us-east-1'
+    session.aws_region = "us-east-1"
 
-    boto_fs.create_file(config_file, contents=f"""
+    boto_fs.create_file(
+        config_file,
+        contents=f"""
 kms:
     arn: {KEY_ARN}
 parameters:
@@ -267,69 +288,64 @@ parameters:
     - name: 'ssm-param2'
       type: 'String'
       value: 'PlainTextData'
-""")
+""",
+    )
 
     config = ConfigReader(config_file)
     provider = SSMProvider(config)
 
-    assert provider.encrypt() == [{
-        'name': 'ssm-param',
-        'value': 'SecretData'
-    }]
+    assert provider.encrypt() == [{"name": "ssm-param", "value": "SecretData"}]
 
 
-def test_ssm_provider_add(
-    boto_fs
-):
+def test_ssm_provider_add(boto_fs):
     """
-        Should add a new entry to the provider
+    Should add a new entry to the provider
     """
 
-    config_file = 'config.yaml'
+    config_file = "config.yaml"
     session.aws_profile = None
-    session.aws_region = 'us-east-1'
+    session.aws_region = "us-east-1"
 
-    boto_fs.create_file(config_file, contents=f"""
+    boto_fs.create_file(
+        config_file,
+        contents=f"""
 kms:
     arn: {KEY_ARN}
 parameters:
     - name: 'ssm-param'
       type: 'String'
       value: 'PlainTextData'
-""")
+""",
+    )
 
     config = ConfigReader(config_file)
     provider = SSMProvider(config)
 
-    assert isinstance(provider.add({
-        'name': 'ssm-param2',
-        'type': 'String',
-        'value': 'PlainTextData2'
-    }), SSMParameterEntry)
+    assert isinstance(
+        provider.add(
+            {"name": "ssm-param2", "type": "String", "value": "PlainTextData2"}
+        ),
+        SSMParameterEntry,
+    )
 
-    assert provider._get_data_entries() == [{
-        'name': 'ssm-param',
-        'type': 'String',
-        'value': 'PlainTextData'
-    }, {
-        'name': 'ssm-param2',
-        'type': 'String',
-        'value': 'PlainTextData2'
-    }]
+    assert provider._get_data_entries() == [
+        {"name": "ssm-param", "type": "String", "value": "PlainTextData"},
+        {"name": "ssm-param2", "type": "String", "value": "PlainTextData2"},
+    ]
 
 
-def test_ssm_provider_update(
-    boto_fs
-):
+def test_ssm_provider_update(boto_fs):
     """
-        Should update an existing entry
+    Should update an existing entry
     """
 
-    config_file = 'config.yaml'
+    config_file = "config.yaml"
     session.aws_profile = None
-    session.aws_region = 'us-east-1'
+    session.aws_region = "us-east-1"
 
-    boto_fs.create_file(config_file, contents=f"""
+    boto_fs.create_file(
+        config_file,
+        contents=f"""
 kms:
     arn: {KEY_ARN}
 parameters:
@@ -339,124 +355,118 @@ parameters:
     - name: 'ssm-param2'
       type: 'String'
       value: 'PlainTextData'
-""")
+""",
+    )
 
     config = ConfigReader(config_file)
     provider = SSMProvider(config)
 
-    provider.update({
-        'name': 'ssm-param',
-        'type': 'String',
-        'value': 'PlainTextData',
-        'description': 'Desc'
-    })
+    provider.update(
+        {
+            "name": "ssm-param",
+            "type": "String",
+            "value": "PlainTextData",
+            "description": "Desc",
+        }
+    )
 
-    assert provider._get_data_entries() == [{
-        'name': 'ssm-param',
-        'type': 'String',
-        'value': 'PlainTextData',
-        'description': 'Desc'
-    }, {
-        'name': 'ssm-param2',
-        'type': 'String',
-        'value': 'PlainTextData'
-    }]
+    assert provider._get_data_entries() == [
+        {
+            "name": "ssm-param",
+            "type": "String",
+            "value": "PlainTextData",
+            "description": "Desc",
+        },
+        {"name": "ssm-param2", "type": "String", "value": "PlainTextData"},
+    ]
 
 
-@patch('aws_secrets.miscellaneous.kms.decrypt')
-def test_ssm_provider_deploy_dry_run(
-    mock_decrypt,
-    boto_fs,
-    capsys
-):
+@patch("aws_secrets.miscellaneous.kms.decrypt")
+def test_ssm_provider_deploy_dry_run(mock_decrypt, boto_fs, capsys):
     """
-        Should deploy the SSM parameter changes
+    Should deploy the SSM parameter changes
     """
 
-    mock_decrypt.return_value = b'PlainTextData'
-    client = boto3.client('ssm')
+    mock_decrypt.return_value = b"PlainTextData"
+    client = boto3.client("ssm")
 
-    with patch.object(boto3.Session, 'client') as mock_client:
+    with patch.object(boto3.Session, "client") as mock_client:
         with Stubber(client) as stubber:
             mock_client.return_value = client
-            stubber.add_response('describe_parameters', {
-                'Parameters': []
-            }, {
-                'ParameterFilters': [
-                    {
-                        'Key': 'Name',
-                        'Option': 'Equals',
-                        'Values': ['ssm-param']
-                    }
-                ]
-            })
-            stubber.add_response('describe_parameters', {
-                'Parameters': [{
-                    'Name': 'ssm-param1',
-                    'Description': '',
-                    'Type': 'String',
-                    'Tier': 'Standard'
-                }]
-            }, {
-                'ParameterFilters': [
-                    {
-                        'Key': 'Name',
-                        'Option': 'Equals',
-                        'Values': ['ssm-param1']
-                    }
-                ]
-            })
-            stubber.add_response('get_parameter', {
-                'Parameter': {
-                    'Value': 'PlainTextData'
-                }
-            }, {
-                'Name': 'ssm-param1',
-                'WithDecryption': False
-            })
-            stubber.add_response('list_tags_for_resource', {
-                'TagList': []
-            }, {
-                'ResourceType': 'Parameter',
-                'ResourceId': 'ssm-param1'
-            })
-            stubber.add_response('describe_parameters', {
-                'Parameters': [{
-                    'Name': 'ssm-param2',
-                    'Description': '',
-                    'Type': 'SecureString',
-                    'Tier': 'Standard'
-                }]
-            }, {
-                'ParameterFilters': [
-                    {
-                        'Key': 'Name',
-                        'Option': 'Equals',
-                        'Values': ['ssm-param2']
-                    }
-                ]
-            })
-            stubber.add_response('get_parameter', {
-                'Parameter': {
-                    'Value': 'PlainTextData2'
-                }
-            }, {
-                'Name': 'ssm-param2',
-                'WithDecryption': True
-            })
-            stubber.add_response('list_tags_for_resource', {
-                'TagList': []
-            }, {
-                'ResourceType': 'Parameter',
-                'ResourceId': 'ssm-param2'
-            })
+            stubber.add_response(
+                "describe_parameters",
+                {"Parameters": []},
+                {
+                    "ParameterFilters": [
+                        {"Key": "Name", "Option": "Equals", "Values": ["ssm-param"]}
+                    ]
+                },
+            )
+            stubber.add_response(
+                "describe_parameters",
+                {
+                    "Parameters": [
+                        {
+                            "Name": "ssm-param1",
+                            "Description": "",
+                            "Type": "String",
+                            "Tier": "Standard",
+                        }
+                    ]
+                },
+                {
+                    "ParameterFilters": [
+                        {"Key": "Name", "Option": "Equals", "Values": ["ssm-param1"]}
+                    ]
+                },
+            )
+            stubber.add_response(
+                "get_parameter",
+                {"Parameter": {"Value": "PlainTextData"}},
+                {"Name": "ssm-param1", "WithDecryption": False},
+            )
+            stubber.add_response(
+                "list_tags_for_resource",
+                {"TagList": []},
+                {"ResourceType": "Parameter", "ResourceId": "ssm-param1"},
+            )
+            stubber.add_response(
+                "describe_parameters",
+                {
+                    "Parameters": [
+                        {
+                            "Name": "ssm-param2",
+                            "Description": "",
+                            "Type": "SecureString",
+                            "Tier": "Standard",
+                        }
+                    ]
+                },
+                {
+                    "ParameterFilters": [
+                        {"Key": "Name", "Option": "Equals", "Values": ["ssm-param2"]}
+                    ]
+                },
+            )
+            stubber.add_response(
+                "get_parameter",
+                {"Parameter": {"Value": "PlainTextData2"}},
+                {"Name": "ssm-param2", "WithDecryption": True},
+            )
+            stubber.add_response(
+                "list_tags_for_resource",
+                {"TagList": []},
+                {"ResourceType": "Parameter", "ResourceId": "ssm-param2"},
+            )
 
-            config_file = 'config.yaml'
-            secrets_file = 'config.secrets.yaml'
+            config_file = "config.yaml"
+            secrets_file = "config.secrets.yaml"
             session.aws_profile = None
-            session.aws_region = 'us-east-1'
+            session.aws_region = "us-east-1"
 
-            boto_fs.create_file(config_file, contents=f"""
+            boto_fs.create_file(
+                config_file,
+                contents=f"""
 kms:
     arn: {KEY_ARN}
 parameters:
@@ -468,123 +478,245 @@ parameters:
       value: 'PlainTextData'
     - name: 'ssm-param2'
       type: 'SecureString'
-        """)
+        """,
+            )
 
-            boto_fs.create_file(secrets_file, contents="""
+            boto_fs.create_file(
+                secrets_file,
+                contents="""
 parameters:
     - name: 'ssm-param2'
       value: 'SecretData'
-        """)
+        """,
+            )
 
             config = ConfigReader(config_file)
             provider = SSMProvider(config)
 
-            provider.deploy('ssm-param*', True, False)
+            provider.deploy("ssm-param*", True, False, True)
 
             captured = capsys.readouterr()
 
             assert "Parameter: [ssm-param]\n--> New Parameter\n" in captured.out
-            assert "Parameter: [ssm-param2]\n--> Changes:\n   -->" + \
-                " Value:\n          Old Value: PlainTextData2\n          New Value: PlainTextData\n" in captured.out
+            assert (
+                "Parameter: [ssm-param2]\n--> Changes:\n   -->"
+                + " Value:\n          Old Value: PlainTextData2\n          New Value: PlainTextData\n"
+                in captured.out
+            )
 
 
-@patch('aws_secrets.miscellaneous.kms.decrypt')
-@patch('click.confirm')
-def test_ssm_provider_deploy_confirm_no(
-    mock_confirm,
-    mock_decrypt,
-    boto_fs,
-    capsys
-):
+@patch("aws_secrets.miscellaneous.kms.decrypt")
+def test_ssm_provider_deploy_dry_run_no_diff(mock_decrypt, boto_fs, capsys):
     """
-        Should deploy the SSM parameter changes
+    Should deploy the SSM parameter changes
     """
 
-    mock_decrypt.return_value = b'PlainTextData'
+    mock_decrypt.return_value = b"PlainTextData"
+    client = boto3.client("ssm")
+
+    with patch.object(boto3.Session, "client") as mock_client:
+        with Stubber(client) as stubber:
+            mock_client.return_value = client
+            stubber.add_response(
+                "describe_parameters",
+                {"Parameters": []},
+                {
+                    "ParameterFilters": [
+                        {"Key": "Name", "Option": "Equals", "Values": ["ssm-param"]}
+                    ]
+                },
+            )
+            stubber.add_response(
+                "describe_parameters",
+                {
+                    "Parameters": [
+                        {
+                            "Name": "ssm-param1",
+                            "Description": "",
+                            "Type": "String",
+                            "Tier": "Standard",
+                        }
+                    ]
+                },
+                {
+                    "ParameterFilters": [
+                        {"Key": "Name", "Option": "Equals", "Values": ["ssm-param1"]}
+                    ]
+                },
+            )
+            stubber.add_response(
+                "get_parameter",
+                {"Parameter": {"Value": "PlainTextData"}},
+                {"Name": "ssm-param1", "WithDecryption": False},
+            )
+            stubber.add_response(
+                "list_tags_for_resource",
+                {"TagList": []},
+                {"ResourceType": "Parameter", "ResourceId": "ssm-param1"},
+            )
+            stubber.add_response(
+                "describe_parameters",
+                {
+                    "Parameters": [
+                        {
+                            "Name": "ssm-param2",
+                            "Description": "",
+                            "Type": "SecureString",
+                            "Tier": "Standard",
+                        }
+                    ]
+                },
+                {
+                    "ParameterFilters": [
+                        {"Key": "Name", "Option": "Equals", "Values": ["ssm-param2"]}
+                    ]
+                },
+            )
+            stubber.add_response(
+                "get_parameter",
+                {"Parameter": {"Value": "PlainTextData2"}},
+                {"Name": "ssm-param2", "WithDecryption": True},
+            )
+            stubber.add_response(
+                "list_tags_for_resource",
+                {"TagList": []},
+                {"ResourceType": "Parameter", "ResourceId": "ssm-param2"},
+            )
+
+            config_file = "config.yaml"
+            secrets_file = "config.secrets.yaml"
+            session.aws_profile = None
+            session.aws_region = "us-east-1"
+
+            boto_fs.create_file(
+                config_file,
+                contents=f"""
+kms:
+    arn: {KEY_ARN}
+parameters:
+    - name: 'ssm-param'
+      type: 'String'
+      value: 'PlainTextData'
+    - name: 'ssm-param1'
+      type: 'String'
+      value: 'PlainTextData'
+    - name: 'ssm-param2'
+      type: 'SecureString'
+        """,
+            )
+
+            boto_fs.create_file(
+                secrets_file,
+                contents="""
+parameters:
+    - name: 'ssm-param2'
+      value: 'SecretData'
+        """,
+            )
+
+            config = ConfigReader(config_file)
+            provider = SSMProvider(config)
+
+            provider.deploy("ssm-param*", True, False, False)
+
+            captured = capsys.readouterr()
+
+            assert "Parameter: [ssm-param]\n--> New Parameter\n" in captured.out
+            assert (
+                "Parameter: [ssm-param2]\n--> Parameter has changes, "
+                + "(use --show-diff to see the changes, not recommended when running in CI/CD)\n"
+                in captured.out
+            )
+
+
+@patch("aws_secrets.miscellaneous.kms.decrypt")
+@patch("click.confirm")
+def test_ssm_provider_deploy_confirm_no(mock_confirm, mock_decrypt, boto_fs, capsys):
+    """
+    Should deploy the SSM parameter changes
+    """
+
+    mock_decrypt.return_value = b"PlainTextData"
     mock_confirm.return_value = False
-    client = boto3.client('ssm')
+    client = boto3.client("ssm")
 
-    with patch.object(boto3.Session, 'client') as mock_client:
+    with patch.object(boto3.Session, "client") as mock_client:
         with Stubber(client) as stubber:
             mock_client.return_value = client
-            stubber.add_response('describe_parameters', {
-                'Parameters': []
-            }, {
-                'ParameterFilters': [
-                    {
-                        'Key': 'Name',
-                        'Option': 'Equals',
-                        'Values': ['ssm-param']
-                    }
-                ]
-            })
-            stubber.add_response('describe_parameters', {
-                'Parameters': [{
-                    'Name': 'ssm-param1',
-                    'Description': '',
-                    'Type': 'String',
-                    'Tier': 'Standard'
-                }]
-            }, {
-                'ParameterFilters': [
-                    {
-                        'Key': 'Name',
-                        'Option': 'Equals',
-                        'Values': ['ssm-param1']
-                    }
-                ]
-            })
-            stubber.add_response('get_parameter', {
-                'Parameter': {
-                    'Value': 'PlainTextData'
-                }
-            }, {
-                'Name': 'ssm-param1',
-                'WithDecryption': False
-            })
-            stubber.add_response('list_tags_for_resource', {
-                'TagList': []
-            }, {
-                'ResourceType': 'Parameter',
-                'ResourceId': 'ssm-param1'
-            })
-            stubber.add_response('describe_parameters', {
-                'Parameters': [{
-                    'Name': 'ssm-param2',
-                    'Description': '',
-                    'Type': 'SecureString',
-                    'Tier': 'Standard'
-                }]
-            }, {
-                'ParameterFilters': [
-                    {
-                        'Key': 'Name',
-                        'Option': 'Equals',
-                        'Values': ['ssm-param2']
-                    }
-                ]
-            })
-            stubber.add_response('get_parameter', {
-                'Parameter': {
-                    'Value': 'PlainTextData2'
-                }
-            }, {
-                'Name': 'ssm-param2',
-                'WithDecryption': True
-            })
-            stubber.add_response('list_tags_for_resource', {
-                'TagList': []
-            }, {
-                'ResourceType': 'Parameter',
-                'ResourceId': 'ssm-param2'
-            })
+            stubber.add_response(
+                "describe_parameters",
+                {"Parameters": []},
+                {
+                    "ParameterFilters": [
+                        {"Key": "Name", "Option": "Equals", "Values": ["ssm-param"]}
+                    ]
+                },
+            )
+            stubber.add_response(
+                "describe_parameters",
+                {
+                    "Parameters": [
+                        {
+                            "Name": "ssm-param1",
+                            "Description": "",
+                            "Type": "String",
+                            "Tier": "Standard",
+                        }
+                    ]
+                },
+                {
+                    "ParameterFilters": [
+                        {"Key": "Name", "Option": "Equals", "Values": ["ssm-param1"]}
+                    ]
+                },
+            )
+            stubber.add_response(
+                "get_parameter",
+                {"Parameter": {"Value": "PlainTextData"}},
+                {"Name": "ssm-param1", "WithDecryption": False},
+            )
+            stubber.add_response(
+                "list_tags_for_resource",
+                {"TagList": []},
+                {"ResourceType": "Parameter", "ResourceId": "ssm-param1"},
+            )
+            stubber.add_response(
+                "describe_parameters",
+                {
+                    "Parameters": [
+                        {
+                            "Name": "ssm-param2",
+                            "Description": "",
+                            "Type": "SecureString",
+                            "Tier": "Standard",
+                        }
+                    ]
+                },
+                {
+                    "ParameterFilters": [
+                        {"Key": "Name", "Option": "Equals", "Values": ["ssm-param2"]}
+                    ]
+                },
+            )
+            stubber.add_response(
+                "get_parameter",
+                {"Parameter": {"Value": "PlainTextData2"}},
+                {"Name": "ssm-param2", "WithDecryption": True},
+            )
+            stubber.add_response(
+                "list_tags_for_resource",
+                {"TagList": []},
+                {"ResourceType": "Parameter", "ResourceId": "ssm-param2"},
+            )
 
-            config_file = 'config.yaml'
-            secrets_file = 'config.secrets.yaml'
+            config_file = "config.yaml"
+            secrets_file = "config.secrets.yaml"
             session.aws_profile = None
-            session.aws_region = 'us-east-1'
+            session.aws_region = "us-east-1"
 
-            boto_fs.create_file(config_file, contents=f"""
+            boto_fs.create_file(
+                config_file,
+                contents=f"""
 kms:
     arn: {KEY_ARN}
 parameters:
@@ -596,141 +728,152 @@ parameters:
       value: 'PlainTextData'
     - name: 'ssm-param2'
       type: 'SecureString'
-        """)
+        """,
+            )
 
-            boto_fs.create_file(secrets_file, contents="""
+            boto_fs.create_file(
+                secrets_file,
+                contents="""
 parameters:
     - name: 'ssm-param2'
       value: 'SecretData'
-        """)
+        """,
+            )
 
             config = ConfigReader(config_file)
             provider = SSMProvider(config)
 
-            provider.deploy('ssm-param*', False, True)
+            provider.deploy("ssm-param*", False, True, True)
 
             captured = capsys.readouterr()
 
             assert "Parameter: [ssm-param]\n--> New Parameter\n" in captured.out
-            assert "Parameter: [ssm-param2]\n--> Changes:\n   -->" + \
-                " Value:\n          Old Value: PlainTextData2\n          New Value: PlainTextData\n" in captured.out
+            assert (
+                "Parameter: [ssm-param2]\n--> Changes:\n   -->"
+                + " Value:\n          Old Value: PlainTextData2\n          New Value: PlainTextData\n"
+                in captured.out
+            )
 
 
-@patch('aws_secrets.miscellaneous.kms.decrypt')
-def test_ssm_provider_deploy(
-    mock_decrypt,
-    boto_fs,
-    capsys
-):
+@patch("aws_secrets.miscellaneous.kms.decrypt")
+def test_ssm_provider_deploy(mock_decrypt, boto_fs, capsys):
     """
-        Should deploy the SSM parameter changes
+    Should deploy the SSM parameter changes
     """
 
-    mock_decrypt.return_value = b'PlainTextData'
-    client = boto3.client('ssm')
+    mock_decrypt.return_value = b"PlainTextData"
+    client = boto3.client("ssm")
 
-    with patch.object(boto3.Session, 'client') as mock_client:
+    with patch.object(boto3.Session, "client") as mock_client:
         with Stubber(client) as stubber:
             mock_client.return_value = client
-            stubber.add_response('describe_parameters', {
-                'Parameters': []
-            }, {
-                'ParameterFilters': [
-                    {
-                        'Key': 'Name',
-                        'Option': 'Equals',
-                        'Values': ['ssm-param']
-                    }
-                ]
-            })
-            stubber.add_response('put_parameter', {}, {
-                'Name': 'ssm-param',
-                'Description': '',
-                'Type': 'String',
-                'Value': 'PlainTextData',
-                'Tier': 'Standard',
-                'Tags': []
-            })
-            stubber.add_response('describe_parameters', {
-                'Parameters': [{
-                    'Name': 'ssm-param1',
-                    'Description': '',
-                    'Type': 'String',
-                    'Tier': 'Standard'
-                }]
-            }, {
-                'ParameterFilters': [
-                    {
-                        'Key': 'Name',
-                        'Option': 'Equals',
-                        'Values': ['ssm-param1']
-                    }
-                ]
-            })
-            stubber.add_response('get_parameter', {
-                'Parameter': {
-                    'Value': 'PlainTextData'
-                }
-            }, {
-                'Name': 'ssm-param1',
-                'WithDecryption': False
-            })
-            stubber.add_response('list_tags_for_resource', {
-                'TagList': []
-            }, {
-                'ResourceType': 'Parameter',
-                'ResourceId': 'ssm-param1'
-            })
-            stubber.add_response('describe_parameters', {
-                'Parameters': [{
-                    'Name': 'ssm-param2',
-                    'Description': '',
-                    'Type': 'SecureString',
-                    'Tier': 'Standard'
-                }]
-            }, {
-                'ParameterFilters': [
-                    {
-                        'Key': 'Name',
-                        'Option': 'Equals',
-                        'Values': ['ssm-param2']
-                    }
-                ]
-            })
-            stubber.add_response('get_parameter', {
-                'Parameter': {
-                    'Value': 'PlainTextData2'
-                }
-            }, {
-                'Name': 'ssm-param2',
-                'WithDecryption': True
-            })
-            stubber.add_response('list_tags_for_resource', {
-                'TagList': []
-            }, {
-                'ResourceType': 'Parameter',
-                'ResourceId': 'ssm-param2'
-            })
-            stubber.add_response('put_parameter', {}, {
-                'Name': 'ssm-param2',
-                'Description': '',
-                'Type': 'SecureString',
-                'Value': 'PlainTextData',
-                'Tier': 'Standard',
-                'Overwrite': True
-            })
-            stubber.add_response('remove_tags_from_resource', {}, {
-                'ResourceType': 'Parameter',
-                'ResourceId': 'ssm-param2',
-                'TagKeys': []
-            })
+            stubber.add_response(
+                "describe_parameters",
+                {"Parameters": []},
+                {
+                    "ParameterFilters": [
+                        {"Key": "Name", "Option": "Equals", "Values": ["ssm-param"]}
+                    ]
+                },
+            )
+            stubber.add_response(
+                "put_parameter",
+                {},
+                {
+                    "Name": "ssm-param",
+                    "Description": "",
+                    "Type": "String",
+                    "Value": "PlainTextData",
+                    "Tier": "Standard",
+                    "Tags": [],
+                },
+            )
+            stubber.add_response(
+                "describe_parameters",
+                {
+                    "Parameters": [
+                        {
+                            "Name": "ssm-param1",
+                            "Description": "",
+                            "Type": "String",
+                            "Tier": "Standard",
+                        }
+                    ]
+                },
+                {
+                    "ParameterFilters": [
+                        {"Key": "Name", "Option": "Equals", "Values": ["ssm-param1"]}
+                    ]
+                },
+            )
+            stubber.add_response(
+                "get_parameter",
+                {"Parameter": {"Value": "PlainTextData"}},
+                {"Name": "ssm-param1", "WithDecryption": False},
+            )
+            stubber.add_response(
+                "list_tags_for_resource",
+                {"TagList": []},
+                {"ResourceType": "Parameter", "ResourceId": "ssm-param1"},
+            )
+            stubber.add_response(
+                "describe_parameters",
+                {
+                    "Parameters": [
+                        {
+                            "Name": "ssm-param2",
+                            "Description": "",
+                            "Type": "SecureString",
+                            "Tier": "Standard",
+                        }
+                    ]
+                },
+                {
+                    "ParameterFilters": [
+                        {"Key": "Name", "Option": "Equals", "Values": ["ssm-param2"]}
+                    ]
+                },
+            )
+            stubber.add_response(
+                "get_parameter",
+                {"Parameter": {"Value": "PlainTextData2"}},
+                {"Name": "ssm-param2", "WithDecryption": True},
+            )
+            stubber.add_response(
+                "list_tags_for_resource",
+                {"TagList": []},
+                {"ResourceType": "Parameter", "ResourceId": "ssm-param2"},
+            )
+            stubber.add_response(
+                "put_parameter",
+                {},
+                {
+                    "Name": "ssm-param2",
+                    "Description": "",
+                    "Type": "SecureString",
+                    "Value": "PlainTextData",
+                    "Tier": "Standard",
+                    "Overwrite": True,
+                },
+            )
+            stubber.add_response(
+                "remove_tags_from_resource",
+                {},
+                {
+                    "ResourceType": "Parameter",
+                    "ResourceId": "ssm-param2",
+                    "TagKeys": [],
+                },
+            )
 
-            config_file = 'config.yaml'
-            secrets_file = 'config.secrets.yaml'
+            config_file = "config.yaml"
+            secrets_file = "config.secrets.yaml"
             session.aws_profile = None
-            session.aws_region = 'us-east-1'
+            session.aws_region = "us-east-1"
 
-            boto_fs.create_file(config_file, contents=f"""
+            boto_fs.create_file(
+                config_file,
+                contents=f"""
 kms:
     arn: {KEY_ARN}
 parameters:
@@ -742,250 +885,258 @@ parameters:
       value: 'PlainTextData'
     - name: 'ssm-param2'
       type: 'SecureString'
-        """)
+        """,
+            )
 
-            boto_fs.create_file(secrets_file, contents="""
+            boto_fs.create_file(
+                secrets_file,
+                contents="""
 parameters:
     - name: 'ssm-param2'
       value: 'SecretData'
-        """)
+        """,
+            )
 
             config = ConfigReader(config_file)
             provider = SSMProvider(config)
 
-            provider.deploy('ssm-param*', False, False)
+            provider.deploy("ssm-param*", False, False, True)
 
             captured = capsys.readouterr()
 
             assert "Parameter: [ssm-param]\n--> New Parameter\n" in captured.out
-            assert "Parameter: [ssm-param2]\n--> Changes:\n   -->" + \
-                " Value:\n          Old Value: PlainTextData2\n          New Value: PlainTextData\n" in captured.out
+            assert (
+                "Parameter: [ssm-param2]\n--> Changes:\n   -->"
+                + " Value:\n          Old Value: PlainTextData2\n          New Value: PlainTextData\n"
+                in captured.out
+            )
 
 
-@patch('aws_secrets.miscellaneous.kms.decrypt')
-def test_ssm_provider_deploy_no_changes(
-    mock_decrypt,
-    boto_fs,
-    capsys
-):
+@patch("aws_secrets.miscellaneous.kms.decrypt")
+def test_ssm_provider_deploy_no_changes(mock_decrypt, boto_fs, capsys):
     """
-        Should deploy the SSM parameter changes
+    Should deploy the SSM parameter changes
     """
 
-    mock_decrypt.return_value = b'PlainTextData'
-    client = boto3.client('ssm')
+    mock_decrypt.return_value = b"PlainTextData"
+    client = boto3.client("ssm")
 
-    with patch.object(boto3.Session, 'client') as mock_client:
+    with patch.object(boto3.Session, "client") as mock_client:
         with Stubber(client) as stubber:
             mock_client.return_value = client
-            stubber.add_response('describe_parameters', {
-                'Parameters': [{
-                    'Name': 'ssm-param1',
-                    'Description': '',
-                    'Type': 'String',
-                    'Tier': 'Standard'
-                }]
-            }, {
-                'ParameterFilters': [
-                    {
-                        'Key': 'Name',
-                        'Option': 'Equals',
-                        'Values': ['ssm-param1']
-                    }
-                ]
-            })
-            stubber.add_response('get_parameter', {
-                'Parameter': {
-                    'Value': 'PlainTextData'
-                }
-            }, {
-                'Name': 'ssm-param1',
-                'WithDecryption': False
-            })
-            stubber.add_response('list_tags_for_resource', {
-                'TagList': []
-            }, {
-                'ResourceType': 'Parameter',
-                'ResourceId': 'ssm-param1'
-            })
+            stubber.add_response(
+                "describe_parameters",
+                {
+                    "Parameters": [
+                        {
+                            "Name": "ssm-param1",
+                            "Description": "",
+                            "Type": "String",
+                            "Tier": "Standard",
+                        }
+                    ]
+                },
+                {
+                    "ParameterFilters": [
+                        {"Key": "Name", "Option": "Equals", "Values": ["ssm-param1"]}
+                    ]
+                },
+            )
+            stubber.add_response(
+                "get_parameter",
+                {"Parameter": {"Value": "PlainTextData"}},
+                {"Name": "ssm-param1", "WithDecryption": False},
+            )
+            stubber.add_response(
+                "list_tags_for_resource",
+                {"TagList": []},
+                {"ResourceType": "Parameter", "ResourceId": "ssm-param1"},
+            )
 
-            config_file = 'config.yaml'
+            config_file = "config.yaml"
             session.aws_profile = None
-            session.aws_region = 'us-east-1'
+            session.aws_region = "us-east-1"
 
-            boto_fs.create_file(config_file, contents=f"""
+            boto_fs.create_file(
+                config_file,
+                contents=f"""
 kms:
     arn: {KEY_ARN}
 parameters:
     - name: 'ssm-param1'
       type: 'String'
       value: 'PlainTextData'
-        """)
+        """,
+            )
 
             config = ConfigReader(config_file)
             provider = SSMProvider(config)
 
-            provider.deploy('ssm-param*', False, False)
+            provider.deploy("ssm-param*", False, False, True)
 
             captured = capsys.readouterr()
 
             assert "no changes required" in captured.out
 
 
-@patch('aws_secrets.miscellaneous.kms.decrypt')
-@patch('click.confirm')
-def test_ssm_provider_deploy_non_replaceable_attrs(
-    mock_confirm,
-    mock_decrypt,
-    boto_fs
-):
+@patch("aws_secrets.miscellaneous.kms.decrypt")
+@patch("click.confirm")
+def test_ssm_provider_deploy_non_replaceable_attrs(mock_confirm, mock_decrypt, boto_fs):
     """
-        Should deploy the SSM parameter changes
+    Should deploy the SSM parameter changes
     """
 
-    mock_decrypt.return_value = b'PlainTextData'
+    mock_decrypt.return_value = b"PlainTextData"
     mock_confirm.return_value = True
-    client = boto3.client('ssm')
+    client = boto3.client("ssm")
 
-    with patch.object(boto3.Session, 'client') as mock_client:
+    with patch.object(boto3.Session, "client") as mock_client:
         with Stubber(client) as stubber:
             mock_client.return_value = client
-            stubber.add_response('describe_parameters', {
-                'Parameters': [{
-                    'Name': 'ssm-param1',
-                    'Description': '',
-                    'Type': 'String',
-                    'Tier': 'Standard'
-                }]
-            }, {
-                'ParameterFilters': [
-                    {
-                        'Key': 'Name',
-                        'Option': 'Equals',
-                        'Values': ['ssm-param1']
-                    }
-                ]
-            })
-            stubber.add_response('get_parameter', {
-                'Parameter': {
-                    'Value': 'PlainTextData'
-                }
-            }, {
-                'Name': 'ssm-param1',
-                'WithDecryption': False
-            })
-            stubber.add_response('list_tags_for_resource', {
-                'TagList': []
-            }, {
-                'ResourceType': 'Parameter',
-                'ResourceId': 'ssm-param1'
-            })
-            stubber.add_response('delete_parameter', {}, {
-                'Name': 'ssm-param1'
-            })
-            stubber.add_response('put_parameter', {}, {
-                'Name': 'ssm-param1',
-                'Description': '',
-                'Type': 'SecureString',
-                'Value': 'PlainTextData',
-                'Tier': 'Standard',
-                'Tags': []
-            })
+            stubber.add_response(
+                "describe_parameters",
+                {
+                    "Parameters": [
+                        {
+                            "Name": "ssm-param1",
+                            "Description": "",
+                            "Type": "String",
+                            "Tier": "Standard",
+                        }
+                    ]
+                },
+                {
+                    "ParameterFilters": [
+                        {"Key": "Name", "Option": "Equals", "Values": ["ssm-param1"]}
+                    ]
+                },
+            )
+            stubber.add_response(
+                "get_parameter",
+                {"Parameter": {"Value": "PlainTextData"}},
+                {"Name": "ssm-param1", "WithDecryption": False},
+            )
+            stubber.add_response(
+                "list_tags_for_resource",
+                {"TagList": []},
+                {"ResourceType": "Parameter", "ResourceId": "ssm-param1"},
+            )
+            stubber.add_response("delete_parameter", {}, {"Name": "ssm-param1"})
+            stubber.add_response(
+                "put_parameter",
+                {},
+                {
+                    "Name": "ssm-param1",
+                    "Description": "",
+                    "Type": "SecureString",
+                    "Value": "PlainTextData",
+                    "Tier": "Standard",
+                    "Tags": [],
+                },
+            )
 
-            config_file = 'config.yaml'
-            secrets_file = 'config.secrets.yaml'
+            config_file = "config.yaml"
+            secrets_file = "config.secrets.yaml"
             session.aws_profile = None
-            session.aws_region = 'us-east-1'
+            session.aws_region = "us-east-1"
 
-            boto_fs.create_file(config_file, contents=f"""
+            boto_fs.create_file(
+                config_file,
+                contents=f"""
 kms:
     arn: {KEY_ARN}
 parameters:
     - name: 'ssm-param1'
       type: 'SecureString'
-        """)
+        """,
+            )
 
-            boto_fs.create_file(secrets_file, contents="""
+            boto_fs.create_file(
+                secrets_file,
+                contents="""
 parameters:
     - name: 'ssm-param1'
       value: 'SecretData'
-        """)
+        """,
+            )
 
             config = ConfigReader(config_file)
             provider = SSMProvider(config)
 
-            provider.deploy('ssm-param*', False, False)
+            provider.deploy("ssm-param*", False, False, True)
 
 
-@patch('aws_secrets.miscellaneous.kms.decrypt')
-@patch('click.confirm')
+@patch("aws_secrets.miscellaneous.kms.decrypt")
+@patch("click.confirm")
 def test_ssm_provider_deploy_non_replaceable_attrs_confirm_no(
-    mock_confirm,
-    mock_decrypt,
-    boto_fs
+    mock_confirm, mock_decrypt, boto_fs
 ):
     """
-        Should deploy the SSM parameter changes
+    Should deploy the SSM parameter changes
     """
 
-    mock_decrypt.return_value = b'PlainTextData'
+    mock_decrypt.return_value = b"PlainTextData"
     mock_confirm.return_value = False
-    client = boto3.client('ssm')
+    client = boto3.client("ssm")
 
-    with patch.object(boto3.Session, 'client') as mock_client:
+    with patch.object(boto3.Session, "client") as mock_client:
         with Stubber(client) as stubber:
             mock_client.return_value = client
-            stubber.add_response('describe_parameters', {
-                'Parameters': [{
-                    'Name': 'ssm-param1',
-                    'Description': '',
-                    'Type': 'String',
-                    'Tier': 'Standard'
-                }]
-            }, {
-                'ParameterFilters': [
-                    {
-                        'Key': 'Name',
-                        'Option': 'Equals',
-                        'Values': ['ssm-param1']
-                    }
-                ]
-            })
-            stubber.add_response('get_parameter', {
-                'Parameter': {
-                    'Value': 'PlainTextData'
-                }
-            }, {
-                'Name': 'ssm-param1',
-                'WithDecryption': False
-            })
-            stubber.add_response('list_tags_for_resource', {
-                'TagList': []
-            }, {
-                'ResourceType': 'Parameter',
-                'ResourceId': 'ssm-param1'
-            })
+            stubber.add_response(
+                "describe_parameters",
+                {
+                    "Parameters": [
+                        {
+                            "Name": "ssm-param1",
+                            "Description": "",
+                            "Type": "String",
+                            "Tier": "Standard",
+                        }
+                    ]
+                },
+                {
+                    "ParameterFilters": [
+                        {"Key": "Name", "Option": "Equals", "Values": ["ssm-param1"]}
+                    ]
+                },
+            )
+            stubber.add_response(
+                "get_parameter",
+                {"Parameter": {"Value": "PlainTextData"}},
+                {"Name": "ssm-param1", "WithDecryption": False},
+            )
+            stubber.add_response(
+                "list_tags_for_resource",
+                {"TagList": []},
+                {"ResourceType": "Parameter", "ResourceId": "ssm-param1"},
+            )
 
-            config_file = 'config.yaml'
-            secrets_file = 'config.secrets.yaml'
+            config_file = "config.yaml"
+            secrets_file = "config.secrets.yaml"
             session.aws_profile = None
-            session.aws_region = 'us-east-1'
+            session.aws_region = "us-east-1"
 
-            boto_fs.create_file(config_file, contents=f"""
+            boto_fs.create_file(
+                config_file,
+                contents=f"""
 kms:
     arn: {KEY_ARN}
 parameters:
     - name: 'ssm-param1'
       type: 'SecureString'
-        """)
+        """,
+            )
 
-            boto_fs.create_file(secrets_file, contents="""
+            boto_fs.create_file(
+                secrets_file,
+                contents="""
 parameters:
     - name: 'ssm-param1'
       value: 'SecretData'
-        """)
+        """,
+            )
 
             config = ConfigReader(config_file)
             provider = SSMProvider(config)
 
-            provider.deploy(None, False, False)
+            provider.deploy(None, False, False, True)


### PR DESCRIPTION
#### Description

This PR adds `--show-diff` to the `aws-secrets deploy` command.

Currently, by default, the changes are printed in the terminal before the deployment, which is fine for the local machine terminal, but not when they are executed in a CI/CD environment.

This PR changes the behavior of the deploy command to not output the changes, only if the user provide the `--show-diff` CLI flag.

#### Checklist

- [x] Update Documentation
- [x] Update CHANGELOG
- [x] Update Functions/Classes Docstrings
- [x] Update unit tests
