### PR TITLE
fix: change the input save keyboard prompt to Alt+Enter (for windows)

### DIFF
--- a/aws_secrets/miscellaneous/prompt.py
+++ b/aws_secrets/miscellaneous/prompt.py
@@ -91,7 +91,7 @@ def get_multiline_input_save_keyboard() -> str:
     is_mac = sys.platform.startswith("darwin")
 
     if is_windows:
-        return "[Ctrl+Enter]"
+        return "[Alt+Enter]"
     elif is_mac:
         return "[Option+Enter]"
 

--- a/aws_secrets/miscellaneous/prompt.py
+++ b/aws_secrets/miscellaneous/prompt.py
@@ -91,7 +91,7 @@ def get_multiline_input_save_keyboard() -> str:
     is_mac = sys.platform.startswith("darwin")
 
     if is_windows:
-        return "[Windows+Enter]"
+        return "[Ctrl+Enter]"
     elif is_mac:
         return "[Option+Enter]"
 


### PR DESCRIPTION
#### Description

This PR changes the `set-parameter` and `set-secret` commands to prompt the correct keyboard input save keys for Windows, a Meta key should correspond to the `Alt` key, not the `Windows` key.
